### PR TITLE
Fix acquisition thread was not recreated when no new samples were pulled

### DIFF
--- a/mne_lsl/stream/_base.py
+++ b/mne_lsl/stream/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
+import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from math import ceil
@@ -265,6 +266,7 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
         self._interrupt = True
         while self._acquisition_thread.is_alive():
             self._acquisition_thread.cancel()
+        time.sleep(0.001)  # give a bit of time to the CPU
         # This method needs to close any inlet/network object and need to end with
         # self._reset_variables().
 
@@ -718,6 +720,7 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
         self._interrupt = True
         while self._acquisition_thread.is_alive():
             self._acquisition_thread.cancel()
+        time.sleep(0.001)  # give a bit of time to the CPU
         yield
         self._interrupt = False
         self._create_acquisition_thread(0)

--- a/mne_lsl/stream/_base.py
+++ b/mne_lsl/stream/_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from math import ceil
@@ -266,7 +265,6 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
         self._interrupt = True
         while self._acquisition_thread.is_alive():
             self._acquisition_thread.cancel()
-        time.sleep(0.001)  # give a bit of time to the CPU
         # This method needs to close any inlet/network object and need to end with
         # self._reset_variables().
 
@@ -720,7 +718,6 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
         self._interrupt = True
         while self._acquisition_thread.is_alive():
             self._acquisition_thread.cancel()
-        time.sleep(0.001)  # give a bit of time to the CPU
         yield
         self._interrupt = False
         self._create_acquisition_thread(0)

--- a/mne_lsl/stream/stream_lsl.py
+++ b/mne_lsl/stream/stream_lsl.py
@@ -207,6 +207,8 @@ class StreamLSL(BaseStream):
             # pull data
             data, timestamps = self._inlet.pull_chunk(timeout=0.0)
             if timestamps.size == 0:
+                if not self._interrupt:
+                    self._create_acquisition_thread(self._acquisition_delay)
                 return None  # interrupt early
 
             # process acquisition window
@@ -242,14 +244,9 @@ class StreamLSL(BaseStream):
                 )
         except Exception as error:
             logger.exception(error)
-            self._reset_variables()
-            return None  # equivalent to an interrupt
+            self._reset_variables()  # disconnects from the stream
         else:
-            if self._interrupt:
-                # don't recreate the thread if we are trying to interrupt acquisition
-                return None
-            else:
-                # recreate the timer thread as it is one-call only
+            if not self._interrupt:
                 self._create_acquisition_thread(self._acquisition_delay)
 
     def _reset_variables(self) -> None:

--- a/mne_lsl/stream/stream_lsl.py
+++ b/mne_lsl/stream/stream_lsl.py
@@ -244,7 +244,7 @@ class StreamLSL(BaseStream):
                 )
         except Exception as error:
             logger.exception(error)
-            self.disconnect()
+            self._reset_variables()  # disconnects from the stream
         else:
             if not self._interrupt:
                 self._create_acquisition_thread(self._acquisition_delay)

--- a/mne_lsl/stream/stream_lsl.py
+++ b/mne_lsl/stream/stream_lsl.py
@@ -244,7 +244,7 @@ class StreamLSL(BaseStream):
                 )
         except Exception as error:
             logger.exception(error)
-            self._reset_variables()  # disconnects from the stream
+            self.disconnect()
         else:
             if not self._interrupt:
                 self._create_acquisition_thread(self._acquisition_delay)


### PR DESCRIPTION
Forgot to recreate the acquisition thread when `timestamps.size == 0` was True.
Might fix issues #112 and #158