### PR TITLE
Replace single-use thread operation with a ThreadPoolExecutor

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   pytest:
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +61,7 @@ jobs:
       - name: Run pytest
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
       - name: Upload to codecov
@@ -111,7 +111,7 @@ jobs:
       - name: Run pytest
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml
       - name: Upload to codecov
@@ -161,7 +161,7 @@ jobs:
       - name: Run pytest
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
       - name: Upload to codecov

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -10,7 +10,7 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   pytest:
-    timeout-minutes: 60
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -59,11 +59,9 @@ jobs:
       - name: Display system information
         run: mne_lsl-sys_info --developer
       - name: Run pytest
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
+        run: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
+        env:
+          MNE_LSL_LOG_LEVEL: DEBUG
       - name: Upload to codecov
         uses: codecov/codecov-action@v4
         with:
@@ -75,7 +73,7 @@ jobs:
           verbose: true  # optional (default = false)
 
   pytest-pip-pre:
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -109,11 +107,9 @@ jobs:
       - name: Display system information
         run: mne_lsl-sys_info --developer
       - name: Run pytest
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml
+        run: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
+        env:
+          MNE_LSL_LOG_LEVEL: DEBUG
       - name: Upload to codecov
         uses: codecov/codecov-action@v4
         with:
@@ -125,7 +121,7 @@ jobs:
           verbose: true  # optional (default = false)
 
   pytest-compat:
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -159,11 +155,9 @@ jobs:
       - name: Display system information
         run: mne_lsl-sys_info --developer
       - name: Run pytest
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
+        run: pytest mne_lsl --cov=mne_lsl --cov-report=xml --cov-config=pyproject.toml -s
+        env:
+          MNE_LSL_LOG_LEVEL: DEBUG
       - name: Upload to codecov
         uses: codecov/codecov-action@v4
         with:

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -30,3 +30,8 @@ API changes
 
 - The :class:`~mne_lsl.player.PlayerLSL` default ``chunk_size`` is now set to 10 instead of 64 samples (:pr:`264` by `Mathieu Scheltienne`_)
 - The ``Player`` and ``Stream`` objects now use a :class:`concurrent.futures.ThreadPoolExecutor` instead of single-use threads (:pr:`264` by `Mathieu Scheltienne`_)
+
+Infrastructure
+--------------
+
+- Improve unit tests by (1) using a ``chunk_size`` of 200 samples in players, (2) running players in a separate process, (3) ensuring concurrent threads are not limited by one thread hogging the limited CI resources (:pr:`264` by `Mathieu Scheltienne`_)

--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -20,7 +20,13 @@ Version 1.4
 ===========
 
 - Fix handling of warnings through the logger (:pr:`243` by `Mathieu Scheltienne`_)
-- Fix handling of CLI arguments through :class:`~mne_lsl.player.PlayerLSL` entry-point (:pr:`246` by `Mathieu Scheltienne`_)AD
+- Fix handling of CLI arguments through :class:`~mne_lsl.player.PlayerLSL` entry-point (:pr:`246` by `Mathieu Scheltienne`_)
 - Change default download directory for the datasets from ``~/mne_data/MNE-LSL`` to ``~/mne_data/MNE-LSL-data`` to match other MNE datasets (:pr:`256` by `Mathieu Scheltienne`_)
 - Add example for a simple real-time QRS R-peak detector (:pr:`256` by `Mathieu Scheltienne`_)
 - Fix push operation by a :class:`~mne_lsl.player.PlayerLSL` with a ``chunk_size`` set to 1 to use :meth:`mne_lsl.lsl.StreamOutlet.push_sample` instead of :meth:`mne_lsl.lsl.StreamOutlet.push_chunk` (:pr:`257` by `Mathieu Scheltienne`_)
+
+API changes
+-----------
+
+- The :class:`~mne_lsl.player.PlayerLSL` default ``chunk_size`` is now set to 10 instead of 64 samples (:pr:`264` by `Mathieu Scheltienne`_)
+- The ``Player`` and ``Stream`` objects now use a :class:`concurrent.futures.ThreadPoolExecutor` instead of single-use threads (:pr:`264` by `Mathieu Scheltienne`_)

--- a/examples/00_peak_detection.py
+++ b/examples/00_peak_detection.py
@@ -369,7 +369,9 @@ class Detector:
 from mne_lsl.player import PlayerLSL as Player
 from mne_lsl.lsl import local_clock
 
-player = Player(fname=sample.data_path() / "sample-ecg-raw.fif", name="ecg-example")
+player = Player(
+    fname=sample.data_path() / "sample-ecg-raw.fif", chunk_size=200, name="ecg-example"
+)
 player.start()
 detector = Detector(4, player.name, "AUX8")
 
@@ -386,9 +388,9 @@ plt.show()
 
 # %%
 # The detection delay displayed is erroneous due to the nature of the LSL stream, being
-# replayed from a local file with a :class:`~mne_lsl.player.PlayerLSL`. The default
-# behavior used by the :class:`~mne_lsl.stream.StreamLSL` sets ``chunk_size=64``, and
-# thus we are pushing 64 samples chunks at a time, corresponding to 62.5 ms at once.
+# replayed from a local file with a :class:`~mne_lsl.player.PlayerLSL`. The chunk size
+# of the :class:`~mne_lsl.player.PlayerLSL` was set to ``chunk_size=200``, and
+# thus we are pushing 200 samples chunks at a time, corresponding to 195 ms at once.
 #
 # This is obviously not compatible with a real-time detection scenario, but ensures that
 # the test and documentation builds successfully on github runners.

--- a/mne_lsl/commands/mne_lsl_player.py
+++ b/mne_lsl/commands/mne_lsl_player.py
@@ -20,7 +20,7 @@ def run():
         type=int,
         metavar="int",
         help="number of samples pushed at once via LSL.",
-        default=16,
+        default=10,
     )
     parser.add_argument(
         "-n",

--- a/mne_lsl/conftest.py
+++ b/mne_lsl/conftest.py
@@ -58,7 +58,7 @@ def pytest_configure(config: pytest.Config) -> None:
         if warning_line and not warning_line.startswith("#"):
             config.addinivalue_line("filterwarnings", warning_line)
     set_log_level_mne("WARNING")  # MNE logger
-    set_log_level(os.getenv("MNE_LSL_LOG_LEVEL", "WARNING"))  # MNE-lsl logger
+    set_log_level(os.getenv("MNE_LSL_LOG_LEVEL", "INFO"))  # MNE-lsl logger
     logger.propagate = True
 
 

--- a/mne_lsl/conftest.py
+++ b/mne_lsl/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
 import inspect
+import logging
 import os
 from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING
@@ -13,6 +14,7 @@ from mne.io import read_raw_fif
 
 from mne_lsl.datasets import testing
 from mne_lsl.lsl import StreamInlet, StreamOutlet
+from mne_lsl.utils._checks import check_verbose
 from mne_lsl.utils.logs import logger
 
 if TYPE_CHECKING:
@@ -27,7 +29,22 @@ if TYPE_CHECKING:
 # 2023-10-20 09:38:21.648 (   9.665s) [IO_P_test_stre  ]         udp_server.cpp:136      3| 0x43e9310 query matches, replying to port 16574  # noqa: E501
 lsl_cfg = NamedTemporaryFile("w", prefix="lsl", suffix=".cfg", delete=False)
 if "LSLAPICFG" not in os.environ:
-    level = int(os.getenv("MNE_LSL_LOG_LEVEL", "2"))
+    verbose = os.getenv("MNE_LSL_LOG_LEVEL", 2)
+    try:
+        verbose = int(verbose)
+    except ValueError:
+        pass
+    verbose = check_verbose(verbose)
+    # LSL logs use '-2- for errors, -1 for warnings, 0  for information and then
+    # 1-9 for increasingly less important details.
+    if logging.ERROR <= verbose:
+        level = -2
+    elif logging.WARNING <= verbose:
+        level = -1
+    elif logging.INFO <= verbose:
+        level = 0
+    else:
+        level = 2
     with lsl_cfg as fid:
         fid.write(f"[log]\nlevel = {level}\n\n[multicast]\nResolveScope = link")
     os.environ["LSLAPICFG"] = lsl_cfg.name

--- a/mne_lsl/conftest.py
+++ b/mne_lsl/conftest.py
@@ -127,13 +127,3 @@ def raw_annotations(raw: BaseRaw) -> BaseRaw:
     )
     raw.set_annotations(annotations)
     return raw
-
-
-@pytest.fixture()
-def mock_lsl_stream(fname: Path, request):
-    """Create a mock LSL stream for testing."""
-    # nest the PlayerLSL import to first write the temporary LSL configuration file
-    from mne_lsl.player import PlayerLSL  # noqa: E402
-
-    with PlayerLSL(fname, name=f"P_{request.node.name}", chunk_size=200) as player:
-        yield player

--- a/mne_lsl/conftest.py
+++ b/mne_lsl/conftest.py
@@ -11,7 +11,6 @@ from mne import Annotations
 from mne import set_log_level as set_log_level_mne
 from mne.io import read_raw_fif
 
-from mne_lsl import set_log_level
 from mne_lsl.datasets import testing
 from mne_lsl.lsl import StreamInlet, StreamOutlet
 from mne_lsl.utils.logs import logger
@@ -58,7 +57,6 @@ def pytest_configure(config: pytest.Config) -> None:
         if warning_line and not warning_line.startswith("#"):
             config.addinivalue_line("filterwarnings", warning_line)
     set_log_level_mne("WARNING")  # MNE logger
-    set_log_level(os.getenv("MNE_LSL_LOG_LEVEL", "INFO"))  # MNE-lsl logger
     logger.propagate = True
 
 

--- a/mne_lsl/datasets/tests/test_datasets.py
+++ b/mne_lsl/datasets/tests/test_datasets.py
@@ -8,6 +8,7 @@ from mne_lsl.datasets.testing import _REGISTRY as _REGISTRY_TESTING
 from mne_lsl.utils._tests import sha256sum
 
 
+@pytest.mark.xfail(reason="Connection issue to the dataset servers.")
 @pytest.mark.parametrize("dataset", [sample, testing])
 def test_data_path(dataset):
     """Test download if the testing dataset."""
@@ -17,6 +18,7 @@ def test_data_path(dataset):
     assert path.exists()
 
 
+@pytest.mark.xfail(reason="Connection issue to the dataset servers.")
 @pytest.mark.parametrize(
     ("dataset", "registry"), [(sample, _REGISTRY_SAMPLE), (testing, _REGISTRY_TESTING)]
 )

--- a/mne_lsl/datasets/tests/test_datasets.py
+++ b/mne_lsl/datasets/tests/test_datasets.py
@@ -22,6 +22,8 @@ def test_data_path(dataset):
 )
 def test_make_registry(tmp_path, dataset, registry):
     """Test the registrytmp_path making."""
+    if dataset != testing and os.getenv("GITHUB_ACTIONS", "") == "true":
+        pytest.skip("Skip sample dataset download on GitHub Actions.")
     dataset._make_registry(dataset.data_path(), output=tmp_path / "registry.txt")
     assert (tmp_path / "registry.txt").exists()
     assert sha256sum(tmp_path / "registry.txt") == sha256sum(registry)

--- a/mne_lsl/datasets/tests/test_datasets.py
+++ b/mne_lsl/datasets/tests/test_datasets.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from mne_lsl.datasets import sample, testing
@@ -9,6 +11,8 @@ from mne_lsl.utils._tests import sha256sum
 @pytest.mark.parametrize("dataset", [sample, testing])
 def test_data_path(dataset):
     """Test download if the testing dataset."""
+    if dataset != testing and os.getenv("GITHUB_ACTIONS", "") == "true":
+        pytest.skip("Skip sample dataset download on GitHub Actions.")
     path = dataset.data_path()
     assert path.exists()
 

--- a/mne_lsl/lsl/tests/test_functions.py
+++ b/mne_lsl/lsl/tests/test_functions.py
@@ -37,7 +37,7 @@ def test_local_clock():
 
 def test_resolve_streams():
     """Test detection of streams on the network."""
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=0.1)
     assert isinstance(streams, list)
     assert len(streams) == 0
 
@@ -65,23 +65,23 @@ def test_resolve_streams():
     assert sinfo2 in streams
     assert sinfo3 in streams
 
-    streams = resolve_streams(name="test1", minimum=2)
+    streams = resolve_streams(name="test1", minimum=2, timeout=2)
     assert len(streams) == 2
     assert sinfo1 in streams
     assert sinfo2 in streams
 
-    streams = resolve_streams(name="test1", minimum=1)
+    streams = resolve_streams(name="test1", minimum=1, timeout=2)
     assert len(streams) in (1, 2)
 
     streams = resolve_streams(stype="Markers")
     assert len(streams) == 1
     assert sinfo2 in streams
 
-    streams = resolve_streams(name="test2", minimum=2, timeout=1)
+    streams = resolve_streams(name="test2", minimum=2, timeout=2)
     assert len(streams) == 1
     assert sinfo3 in streams
 
-    streams = resolve_streams(name="test1", stype="Markers")
+    streams = resolve_streams(name="test1", stype="Markers", timeout=2)
     assert len(streams) == 1
     assert sinfo2 in streams
 

--- a/mne_lsl/lsl/tests/test_stream_info.py
+++ b/mne_lsl/lsl/tests/test_stream_info.py
@@ -201,7 +201,7 @@ def test_stream_info_properties(close_io):
     inlet = StreamInlet(sinfo)
     with pytest.raises(RuntimeError, match="StreamInlet is not open"):
         inlet.get_sinfo()
-    inlet.open_stream()
+    inlet.open_stream(timeout=10)
     sinfo_ = inlet.get_sinfo()
     assert isinstance(sinfo_.created_at, float)
     assert 0 < sinfo_.created_at
@@ -246,7 +246,7 @@ def test_stream_info_desc_from_info(close_io):
     info_retrieved = outlet.get_sinfo().get_channel_info()
     compare_infos(raw.info, info_retrieved)
     inlet = StreamInlet(sinfo)
-    inlet.open_stream()
+    inlet.open_stream(timeout=10)
     info_retrieved = inlet.get_sinfo().get_channel_info()
     compare_infos(raw.info, info_retrieved)
 

--- a/mne_lsl/lsl/tests/test_stream_inlet.py
+++ b/mne_lsl/lsl/tests/test_stream_inlet.py
@@ -11,6 +11,32 @@ from mne_lsl.lsl.constants import string2numpy
 from mne_lsl.lsl.stream_info import _BaseStreamInfo
 
 
+def _test_properties(inlet, dtype_str, n_channels, name, sfreq, stype):
+    """Test the properties of an inlet against expected values."""
+    assert inlet.dtype == string2numpy.get(dtype_str, dtype_str)
+    assert inlet.n_channels == n_channels
+    assert inlet.name == name
+    assert inlet.sfreq == sfreq
+    assert inlet.stype == stype
+    sinfo = inlet.get_sinfo(timeout=5)
+    assert isinstance(sinfo, _BaseStreamInfo)
+
+
+def _test_numerical_data(data, expected, dtype, ts, n_samples_expected=None):
+    """Check that the pull data match the expected data."""
+    assert isinstance(data, np.ndarray)
+    assert data.dtype == dtype
+    assert_allclose(data, expected)
+    assert data.ndim in (1, 2)
+    if data.ndim == 1:  # pull_sample
+        assert isinstance(ts, float)
+        assert n_samples_expected is None
+    elif data.ndim == 2:  # pull_chunk
+        assert isinstance(ts, np.ndarray)
+        assert ts.size == data.shape[0]
+        assert ts.size == n_samples_expected
+
+
 @pytest.mark.parametrize(
     ("dtype_str", "dtype"),
     [
@@ -259,29 +285,3 @@ def test_time_correction(close_io):
     tc = inlet.time_correction(timeout=3)
     assert isinstance(tc, float)
     close_io()
-
-
-def _test_properties(inlet, dtype_str, n_channels, name, sfreq, stype):
-    """Test the properties of an inlet against expected values."""
-    assert inlet.dtype == string2numpy.get(dtype_str, dtype_str)
-    assert inlet.n_channels == n_channels
-    assert inlet.name == name
-    assert inlet.sfreq == sfreq
-    assert inlet.stype == stype
-    sinfo = inlet.get_sinfo(timeout=5)
-    assert isinstance(sinfo, _BaseStreamInfo)
-
-
-def _test_numerical_data(data, expected, dtype, ts, n_samples_expected=None):
-    """Check that the pull data match the expected data."""
-    assert isinstance(data, np.ndarray)
-    assert data.dtype == dtype
-    assert_allclose(data, expected)
-    assert data.ndim in (1, 2)
-    if data.ndim == 1:  # pull_sample
-        assert isinstance(ts, float)
-        assert n_samples_expected is None
-    elif data.ndim == 2:  # pull_chunk
-        assert isinstance(ts, np.ndarray)
-        assert ts.size == data.shape[0]
-        assert ts.size == n_samples_expected

--- a/mne_lsl/lsl/tests/test_stream_outlet.py
+++ b/mne_lsl/lsl/tests/test_stream_outlet.py
@@ -32,7 +32,7 @@ def test_push_numerical_sample(dtype_str, dtype, close_io):
     _test_properties(outlet, dtype_str, 2, "test", 0.0, "")
     inlet = StreamInlet(sinfo)
     inlet.open_stream(timeout=5)
-    time.sleep(0.1)  # sleep required because of pylsl inlet
+    time.sleep(0.5)  # sleep required because of pylsl inlet
     outlet.push_sample(x)
     data, ts = inlet.pull_sample(timeout=5)
     assert_allclose(data, x)
@@ -52,7 +52,7 @@ def test_push_str_sample(close_io):
     _test_properties(outlet, "string", 2, "test", 0.0, "")
     inlet = StreamInlet(sinfo)
     inlet.open_stream(timeout=5)
-    time.sleep(0.1)  # sleep required because of pylsl inlet
+    time.sleep(0.5)  # sleep required because of pylsl inlet
     outlet.push_sample(x)
     data, ts = inlet.pull_sample(timeout=5)
     assert data == x
@@ -170,7 +170,7 @@ def test_push_chunk_timestamps(dtype_str, dtype, close_io):
     _test_properties(outlet, dtype_str, 2, "test", 1.0, "")
     inlet = StreamInlet(sinfo)
     inlet.open_stream(timeout=5)
-    time.sleep(0.1)  # sleep required because of pylsl inlet
+    time.sleep(0.5)  # sleep required because of pylsl inlet
     # float
     now = np.ceil(local_clock())
     outlet.push_chunk(x, timestamp=now)
@@ -218,7 +218,7 @@ def test_push_chunk_irregularly_sampled_stream(close_io):
     _test_properties(outlet, "float32", 2, "test", 0.0, "")
     inlet = StreamInlet(sinfo)
     inlet.open_stream(timeout=5)
-    time.sleep(0.1)  # sleep required because of pylsl inlet
+    time.sleep(0.5)  # sleep required because of pylsl inlet
     # push with timestamp = None
     now = local_clock()
     outlet.push_chunk(x, timestamp=None)

--- a/mne_lsl/lsl/tests/test_stream_outlet.py
+++ b/mne_lsl/lsl/tests/test_stream_outlet.py
@@ -11,6 +11,17 @@ from mne_lsl.lsl.constants import string2numpy
 from mne_lsl.lsl.stream_info import _BaseStreamInfo
 
 
+def _test_properties(outlet, dtype_str, n_channels, name, sfreq, stype):
+    """Test the properties of an outlet against expected values."""
+    assert outlet.dtype == string2numpy.get(dtype_str, dtype_str)
+    assert outlet.n_channels == n_channels
+    assert outlet.name == name
+    assert outlet.sfreq == sfreq
+    assert outlet.stype == stype
+    sinfo = outlet.get_sinfo()
+    assert isinstance(sinfo, _BaseStreamInfo)
+
+
 @pytest.mark.parametrize(
     ("dtype_str", "dtype"),
     [
@@ -251,14 +262,3 @@ def test_push_chunk_irregularly_sampled_stream(close_io):
     with pytest.raises(RuntimeError, match="was supplied as an array of zeros"):
         outlet.push_chunk(x, timestamp=np.zeros(x.shape[0]))
     close_io()
-
-
-def _test_properties(outlet, dtype_str, n_channels, name, sfreq, stype):
-    """Test the properties of an outlet against expected values."""
-    assert outlet.dtype == string2numpy.get(dtype_str, dtype_str)
-    assert outlet.n_channels == n_channels
-    assert outlet.name == name
-    assert outlet.sfreq == sfreq
-    assert outlet.stype == stype
-    sinfo = outlet.get_sinfo()
-    assert isinstance(sinfo, _BaseStreamInfo)

--- a/mne_lsl/lsl/tests/test_utils.py
+++ b/mne_lsl/lsl/tests/test_utils.py
@@ -20,7 +20,6 @@ def test_check_timeout():
     assert 10000 <= check_timeout(None)
     assert check_timeout(2) == 2
     assert check_timeout(2.2) == 2.2
-
     with pytest.raises(
         TypeError, match="The argument 'timeout' must be a strictly positive"
     ):

--- a/mne_lsl/player/_base.py
+++ b/mne_lsl/player/_base.py
@@ -329,7 +329,6 @@ class BasePlayer(ABC, ContainsMixin, SetChannelsMixin):
             raise RuntimeError(
                 "The player is not started. Use Player.start() to begin streaming."
             )
-        self._interrupt = True
         self._executor.shutdown(wait=True, cancel_futures=True)
         # This method must end with self._reset_variables()
 
@@ -358,7 +357,6 @@ class BasePlayer(ABC, ContainsMixin, SetChannelsMixin):
     def _reset_variables(self) -> None:
         """Reset variables for streaming."""
         self._end_streaming = False
-        self._interrupt = False
         self._n_repeated = 1  # number of times the file was repeated
         self._start_idx = 0
         self._streaming_delay = None

--- a/mne_lsl/player/_base.py
+++ b/mne_lsl/player/_base.py
@@ -300,11 +300,10 @@ class BasePlayer(ABC, ContainsMixin, SetChannelsMixin):
         ----------
         meas_date : datetime | float | tuple | None
             The new measurement date.
-            If datetime object, it must be timezone-aware and in UTC.
-            A tuple of (seconds, microseconds) or float (alias for
-            ``(meas_date, 0)``) can also be passed and a datetime
-            object will be automatically created. If None, will remove
-            the time reference.
+            If datetime object, it must be timezone-aware and in UTC. A tuple of
+            (seconds, microseconds) or float (alias for ``(meas_date, 0)``) can also be
+            passed and a datetime object will be automatically created. If None, will
+            remove the time reference.
 
         Returns
         -------

--- a/mne_lsl/player/_base.py
+++ b/mne_lsl/player/_base.py
@@ -55,7 +55,7 @@ class BasePlayer(ABC, ContainsMixin, SetChannelsMixin):
     def __init__(
         self,
         fname: Union[str, Path, BaseRaw],
-        chunk_size: int = 64,
+        chunk_size: int = 10,
         n_repeat: Union[int, float] = np.inf,
     ) -> None:
         self._chunk_size = ensure_int(chunk_size, "chunk_size")

--- a/mne_lsl/player/player_lsl.py
+++ b/mne_lsl/player/player_lsl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-from threading import Timer
+from time import sleep
 from typing import TYPE_CHECKING
 from warnings import catch_warnings, filterwarnings
 
@@ -28,8 +28,6 @@ class PlayerLSL(BasePlayer):
     %(player_fname)s
     chunk_size : int ``≥ 1``
         Number of samples pushed at once on the :class:`~mne_lsl.lsl.StreamOutlet`.
-        If these chunks are too small then the thread-based timing might not work
-        properly.
     %(n_repeat)s
     name : str | None
         Name of the mock LSL stream. If ``None``, the name ``MNE-LSL-Player`` is used.
@@ -168,22 +166,15 @@ class PlayerLSL(BasePlayer):
         player : instance of :class:`~mne_lsl.player.PlayerLSL`
             The player instance modified in-place.
         """
-        if self._streaming_thread is not None:
-            warn(
-                f"{self._name}: The player is already started. "
-                "Use Player.stop() to stop streaming."
-            )
-            return self
+        super().start()
         self._outlet = StreamOutlet(self._sinfo, self._chunk_size)
         self._outlet_annotations = (
             StreamOutlet(self._sinfo_annotations, 1) if self._annotations else None
         )
         self._streaming_delay = self.chunk_size / self.info["sfreq"]
-        self._streaming_thread = Timer(0, self._stream)
-        self._streaming_thread.daemon = True
         self._target_timestamp = local_clock()
-        self._streaming_thread.start()
-        logger.debug("%s: Started streaming thread", self._name)
+        self._executor.submit(self._stream)
+        logger.debug("%s: Started streaming thread.", self._name)
         return self
 
     @copy_doc(BasePlayer.set_channel_types)
@@ -217,7 +208,7 @@ class PlayerLSL(BasePlayer):
         player : instance of :class:`~mne_lsl.player.PlayerLSL`
             The player instance modified in-place.
         """
-        logger.debug("%s: Stopping", self._name)
+        logger.debug("%s: Stopping.", self._name)
         super().stop()
         self._del_outlets()
         self._reset_variables()
@@ -285,16 +276,14 @@ class PlayerLSL(BasePlayer):
                 self._del_outlets()
                 if self._end_streaming:
                     self._reset_variables()
-                return None  # don't recreate the thread if we are interrupting
+                return None  # don't schedule another task if we are ending
             # figure out how early or late the thread woke up and compensate the
             # delay for the next thread to remain in the neighbourhood of
             # _target_timestamp for the following wake.
             delta = self._target_timestamp - self._streaming_delay - local_clock()
             delay = max(self._streaming_delay + delta, 0)
-            # recreate the timer thread as it is one-call only
-            self._streaming_thread = Timer(delay, self._stream)
-            self._streaming_thread.daemon = True
-            self._streaming_thread.start()
+            sleep(delay)
+            self._executor.submit(self._stream)
 
     def _stream_annotations(
         self, start: int, stop: int, start_timestamp: float

--- a/mne_lsl/player/player_lsl.py
+++ b/mne_lsl/player/player_lsl.py
@@ -272,10 +272,9 @@ class PlayerLSL(BasePlayer):
             self._del_outlets()
             self._reset_variables()
         else:
-            if self._interrupt or self._end_streaming:
+            if self._end_streaming:
                 self._del_outlets()
-                if self._end_streaming:
-                    self._reset_variables()
+                self._reset_variables()
                 return None  # don't schedule another task if we are ending
             # figure out how early or late the thread woke up and compensate the
             # delay for the next thread to remain in the neighbourhood of
@@ -283,7 +282,10 @@ class PlayerLSL(BasePlayer):
             delta = self._target_timestamp - self._streaming_delay - local_clock()
             delay = max(self._streaming_delay + delta, 0)
             sleep(delay)
-            self._executor.submit(self._stream)
+            try:
+                self._executor.submit(self._stream)
+            except RuntimeError:
+                assert self._executor._shutdown  # pragma: no cover
 
     def _stream_annotations(
         self, start: int, stop: int, start_timestamp: float

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -390,7 +390,7 @@ def test_player_n_repeat(raw):
     player = Player(raw, n_repeat=1, name="Player-test_player_n_repeat-1")
     player.start()
     time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
-    assert player._streaming_thread is None
+    assert player._executor is None
     streams = resolve_streams()
     assert len(streams) == 0
     with pytest.raises(RuntimeError, match="player is not started."):
@@ -398,7 +398,7 @@ def test_player_n_repeat(raw):
     player = Player(raw, n_repeat=2, name="Player-test_player_n_repeat-2")
     player.start()
     time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
-    assert player._streaming_thread is not None
+    assert player._executor is not None
     streams = resolve_streams()
     assert len(streams) == 1
     player.stop()

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -21,7 +21,7 @@ from mne_lsl.utils._tests import match_stream_and_raw_data
 
 def _create_inlet(name: str) -> StreamInlet:
     """Create an inlet to the open-stream."""
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=2)
     streams = [stream for stream in streams if stream.name == name]
     assert len(streams) == 1
     inlet = StreamInlet(streams[0])
@@ -32,13 +32,13 @@ def _create_inlet(name: str) -> StreamInlet:
 def test_player(fname, raw, close_io):
     """Test a working and valid player."""
     name = "Player-test_player"
-    player = Player(fname, name=name)
+    player = Player(fname, chunk_size=200, name=name)
     assert "OFF" in player.__repr__()
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
     player.start()
     assert "ON" in player.__repr__()
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=2)
     assert len(streams) == 1
     assert streams[0].name == name
 
@@ -51,7 +51,8 @@ def test_player(fname, raw, close_io):
     inlet.open_stream(timeout=10)
     data, ts = inlet.pull_chunk()
     now = local_clock()
-    assert_allclose(now, ts[-1], rtol=0, atol=0.1)  # 100 ms of freedom for slower CIs
+    # between the chunk size and the slow CIs, we can't expect precise timings
+    assert_allclose(now, ts[-1], rtol=1e-3, atol=1)
     assert data.shape[1] == len(player.info["ch_names"])
 
     # check sampling rate
@@ -86,8 +87,8 @@ def test_player_context_manager(fname):
     name = "Player-test_player_context_manager"
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
-    with Player(fname, name=name):
-        streams = resolve_streams()
+    with Player(fname, chunk_size=200, name=name):
+        streams = resolve_streams(timeout=2)
         assert len(streams) == 1
         assert streams[0].name == name
     streams = resolve_streams(timeout=0.1)
@@ -99,8 +100,8 @@ def test_player_context_manager_raw(raw):
     name = "Player-test_player_context_manager_raw"
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
-    with Player(raw, name=name) as player:
-        streams = resolve_streams()
+    with Player(raw, chunk_size=200, name=name) as player:
+        streams = resolve_streams(timeout=2)
         assert len(streams) == 1
         assert streams[0].name == name
         assert player.info["ch_names"] == raw.info["ch_names"]
@@ -108,7 +109,7 @@ def test_player_context_manager_raw(raw):
     assert len(streams) == 0
 
     with pytest.warns(RuntimeWarning, match="raw file has no annotations"):
-        with Player(raw, name=name, annotations=True) as player:
+        with Player(raw, chunk_size=200, name=name, annotations=True) as player:
             streams = resolve_streams()
             assert len(streams) == 1
             assert streams[0].name == name
@@ -120,16 +121,18 @@ def test_player_context_manager_raw_annotations(raw_annotations):
     name = "Player-test_player_context_manager_raw"
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
-    with Player(raw_annotations, name=name, annotations=False) as player:
-        streams = resolve_streams()
+    with Player(
+        raw_annotations, chunk_size=200, name=name, annotations=False
+    ) as player:
+        streams = resolve_streams(timeout=2)
         assert len(streams) == 1
         assert streams[0].name == name
         assert player.info["ch_names"] == raw_annotations.info["ch_names"]
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
 
-    with Player(raw_annotations, name=name) as player:
-        streams = resolve_streams()
+    with Player(raw_annotations, chunk_size=200, name=name) as player:
+        streams = resolve_streams(timeout=2)
         assert len(streams) == 2
         assert any(stream.name == name for stream in streams)
         assert any(stream.name == f"{name}-annotations" for stream in streams)
@@ -154,7 +157,7 @@ def test_player_invalid_arguments(fname):
 
 def test_player_stop_invalid(fname):
     """Test stopping a player that is not started."""
-    player = Player(fname, name="Player-test_stop_player_invalid")
+    player = Player(fname, chunk_size=200, name="Player-test_stop_player_invalid")
     with pytest.raises(RuntimeError, match="The player is not started"):
         player.stop()
     player.start()
@@ -285,14 +288,10 @@ def test_player_set_channel_types(mock_lsl_stream, raw, close_io):
 def test_player_anonymize(fname):
     """Test anonymization."""
     name = "Player-test_player_anonymize"
-    player = Player(fname, name=name)
+    player = Player(fname, chunk_size=200, name=name)
     assert player.name == name
     assert player.fname == fname
-    player.info["subject_info"] = dict(
-        id=101,
-        first_name="Mathieu",
-        sex=1,
-    )
+    player.info["subject_info"] = dict(id=101, first_name="Mathieu", sex=1)
     with pytest.warns(RuntimeWarning, match="partially implemented"):
         player.anonymize()
     assert player.info["subject_info"] == dict(id=0, first_name="mne_anonymize", sex=0)
@@ -306,7 +305,7 @@ def test_player_anonymize(fname):
 def test_player_set_meas_date(fname):
     """Test player measurement date."""
     name = "Player-test_player_set_meas_date"
-    player = Player(fname, name=name)
+    player = Player(fname, chunk_size=200, name=name)
     assert player.name == name
     assert player.fname == fname
     assert player.info["meas_date"] is None
@@ -326,13 +325,13 @@ def test_player_annotations(raw_annotations, close_io):
     """Test player with annotations."""
     name = "Player-test_player_annotations"
     annotations = sorted(set(raw_annotations.annotations.description))
-    player = Player(raw_annotations, name=name)
+    player = Player(raw_annotations, chunk_size=200, name=name)
     assert player.name == name
     assert player.fname == Path(raw_annotations.filenames[0])
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
     player.start()
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=2)
     assert len(streams) == 2
     assert any(stream.name == name for stream in streams)
     assert any(stream.name == f"{name}-annotations" for stream in streams)
@@ -368,6 +367,7 @@ def test_player_annotations(raw_annotations, close_io):
         idx = np.where(data != 0.0)[0]
         assert_allclose(data[idx], [duration] * idx.size)
         assert_allclose(np.diff(ts[idx]), 2, atol=1e-2)
+    time.sleep(3)
     data, ts = stream.get_data(picks="test1")
     data = data.squeeze()
     idx = np.where(data != 0.0)[0]
@@ -387,19 +387,23 @@ def test_player_annotations(raw_annotations, close_io):
 
 def test_player_n_repeat(raw):
     """Test argument 'n_repeat'."""
-    player = Player(raw, n_repeat=1, name="Player-test_player_n_repeat-1")
+    player = Player(
+        raw, chunk_size=200, n_repeat=1, name="Player-test_player_n_repeat-1"
+    )
     player.start()
     time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
     assert player._executor is None
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
     with pytest.raises(RuntimeError, match="player is not started."):
         player.stop()
-    player = Player(raw, n_repeat=2, name="Player-test_player_n_repeat-2")
+    player = Player(
+        raw, chunk_size=200, n_repeat=4, name="Player-test_player_n_repeat-2"
+    )
     player.start()
     time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
     assert player._executor is not None
-    streams = resolve_streams()
+    streams = resolve_streams(timeout=2)
     assert len(streams) == 1
     player.stop()
 
@@ -422,8 +426,8 @@ def test_player_push_sample(fname):
     name = "Player-test_player_push_sample"
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
-    with Player(fname, name=name, chunk_size=1):
-        streams = resolve_streams()
+    with Player(fname, chunk_size=1, name=name):
+        streams = resolve_streams(timeout=0.5)
         assert len(streams) == 1
         assert streams[0].name == name
     streams = resolve_streams(timeout=0.1)

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -19,16 +19,6 @@ from mne_lsl.stream import StreamLSL as Stream
 from mne_lsl.utils._tests import match_stream_and_raw_data
 
 
-def _create_inlet(name: str) -> StreamInlet:
-    """Create an inlet to the open-stream."""
-    streams = resolve_streams(timeout=2)
-    streams = [stream for stream in streams if stream.name == name]
-    assert len(streams) == 1
-    inlet = StreamInlet(streams[0])
-    inlet.open_stream(timeout=10)
-    return inlet
-
-
 def test_player(fname, raw, close_io):
     """Test a working and valid player."""
     name = "Player-test_player"
@@ -162,6 +152,16 @@ def test_player_stop_invalid(fname):
         player.stop()
     player.start()
     player.stop()
+
+
+def _create_inlet(name: str) -> StreamInlet:
+    """Create an inlet to the open-stream."""
+    streams = resolve_streams(timeout=2)
+    streams = [stream for stream in streams if stream.name == name]
+    assert len(streams) == 1
+    inlet = StreamInlet(streams[0])
+    inlet.open_stream(timeout=10)
+    return inlet
 
 
 def test_player_unit(mock_lsl_stream, raw, close_io):

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -164,6 +164,16 @@ def _create_inlet(name: str) -> StreamInlet:
     return inlet
 
 
+@pytest.fixture()
+def mock_lsl_stream(fname: Path, request):
+    """Create a mock LSL stream for testing."""
+    # nest the PlayerLSL import to first write the temporary LSL configuration file
+    from mne_lsl.player import PlayerLSL  # noqa: E402
+
+    with PlayerLSL(fname, name=f"P_{request.node.name}", chunk_size=200) as player:
+        yield player
+
+
 def test_player_unit(mock_lsl_stream, raw, close_io):
     """Test getting and setting the player channel units."""
     player = mock_lsl_stream

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -401,7 +401,7 @@ def test_player_n_repeat(raw):
         raw, chunk_size=200, n_repeat=1, name="Player-test_player_n_repeat-1"
     )
     player.start()
-    time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
+    time.sleep((raw.times.size / raw.info["sfreq"]) * 1.8)
     assert player._executor is None
     streams = resolve_streams(timeout=0.1)
     assert len(streams) == 0
@@ -411,7 +411,7 @@ def test_player_n_repeat(raw):
         raw, chunk_size=200, n_repeat=4, name="Player-test_player_n_repeat-2"
     )
     player.start()
-    time.sleep((raw.times.size / raw.info["sfreq"]) * 1.1)
+    time.sleep((raw.times.size / raw.info["sfreq"]) * 1.8)
     assert player._executor is not None
     streams = resolve_streams(timeout=2)
     assert len(streams) == 1

--- a/mne_lsl/stream/_base.py
+++ b/mne_lsl/stream/_base.py
@@ -300,7 +300,6 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
             The stream instance modified in-place.
         """
         self._check_connected(name="disconnect()")
-        self._interrupt = True
         self._executor.shutdown(wait=True, cancel_futures=True)
         # This method needs to close any inlet/network object and need to end with
         # self._reset_variables().
@@ -1007,13 +1006,11 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
                 "is not connected. Please open an issue on GitHub and provide the "
                 "error traceback to the developers."
             )
-        self._interrupt = True
         # it's simpler to shutdown the executor entirely and create a new one
         self._executor.shutdown(wait=True, cancel_futures=True)
         try:  # ensure "finally" is reached even when failures occur
             yield
         finally:
-            self._interrupt = False
             self._executor = ThreadPoolExecutor(max_workers=1)
             self._executor.submit(self._acquire)
 
@@ -1057,7 +1054,6 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
         self._executor = None
         self._filters = []
         self._info = None
-        self._interrupt = False
         self._n_new_samples = None
         self._picks_inlet = None
         self._ref_channels = None

--- a/mne_lsl/stream/stream_lsl.py
+++ b/mne_lsl/stream/stream_lsl.py
@@ -293,7 +293,7 @@ class StreamLSL(BaseStream):
             logger.exception(error)
             self._reset_variables()  # disconnects from the stream
             if os.getenv("MNE_LSL_RAISE_STREAM_ERRORS", "false").lower() == "true":
-                raise
+                raise error
         else:
             if not self._interrupt:
                 self._create_acquisition_thread(self._acquisition_delay)

--- a/mne_lsl/stream/stream_lsl.py
+++ b/mne_lsl/stream/stream_lsl.py
@@ -198,7 +198,7 @@ class StreamLSL(BaseStream):
                 ceil(self._bufsize * self._inlet.sfreq), dtype=np.float64
             )
         self._picks_inlet = np.arange(0, self._inlet.n_channels)
-        # submit the first acqusition job
+        # submit the first acquisition job
         self._executor.submit(self._acquire)
         return self
 

--- a/mne_lsl/stream/tests/test_filters.py
+++ b/mne_lsl/stream/tests/test_filters.py
@@ -26,28 +26,6 @@ def sfreq() -> float:
     return 1000.0
 
 
-@pytest.fixture(scope="module")
-def filters(iir_params: dict[str, Any], sfreq: float) -> list[StreamFilter]:
-    """Create a list of valid filters."""
-    l_freqs = (1, 1, 0.1)
-    h_freqs = (40, 15, None)
-    picks = (np.arange(0, 10), np.arange(10, 20), np.arange(20, 30))
-    filters = list()
-    for k, (lfq, hfq, picks_) in enumerate(zip(l_freqs, h_freqs, picks)):
-        filt = create_filter(
-            sfreq=sfreq,
-            l_freq=lfq,
-            h_freq=hfq,
-            iir_params=iir_params,
-        )
-        filt.update(picks=picks_)
-        filt["zi"] = k * filt["zi_unit"]
-        del filt["order"]
-        del filt["ftype"]
-        filters.append(StreamFilter(filt))
-    return filters
-
-
 def test_StreamFilter(iir_params: dict[str, Any], sfreq: float):
     """Test StreamFilter creation."""
     # test deletion of duplicates
@@ -82,6 +60,28 @@ def test_StreamFilter(iir_params: dict[str, Any], sfreq: float):
     filt = StreamFilter(filt)
     assert "order" not in filt
     assert "order" in filt["iir_params"]
+
+
+@pytest.fixture(scope="module")
+def filters(iir_params: dict[str, Any], sfreq: float) -> list[StreamFilter]:
+    """Create a list of valid filters."""
+    l_freqs = (1, 1, 0.1)
+    h_freqs = (40, 15, None)
+    picks = (np.arange(0, 10), np.arange(10, 20), np.arange(20, 30))
+    filters = list()
+    for k, (lfq, hfq, picks_) in enumerate(zip(l_freqs, h_freqs, picks)):
+        filt = create_filter(
+            sfreq=sfreq,
+            l_freq=lfq,
+            h_freq=hfq,
+            iir_params=iir_params,
+        )
+        filt.update(picks=picks_)
+        filt["zi"] = k * filt["zi_unit"]
+        del filt["order"]
+        del filt["ftype"]
+        filters.append(StreamFilter(filt))
+    return filters
 
 
 def test_StreamFilter_comparison(filters: list[StreamFilter]):

--- a/mne_lsl/stream/tests/test_stream_lsl.py
+++ b/mne_lsl/stream/tests/test_stream_lsl.py
@@ -63,7 +63,7 @@ def mock_lsl_stream_int(request):
     data = np.full((5, 1000), np.arange(5).reshape(-1, 1))
     raw = RawArray(data, info)
 
-    with PlayerLSL(raw, name=f"P_{request.node.name}") as player:
+    with PlayerLSL(raw, name=f"P_{request.node.name}", chunk_size=200) as player:
         yield player
 
 
@@ -73,7 +73,9 @@ def mock_lsl_stream_annotations(raw_annotations, request):
     # nest the PlayerLSL import to first write the temporary LSL configuration file
     from mne_lsl.player import PlayerLSL  # noqa: E402
 
-    with PlayerLSL(raw_annotations, name=f"P_{request.node.name}") as player:
+    with PlayerLSL(
+        raw_annotations, name=f"P_{request.node.name}", chunk_size=200
+    ) as player:
         yield player
 
 
@@ -97,7 +99,9 @@ def mock_lsl_stream_sinusoids(raw_sinusoids, request):
     # nest the PlayerLSL import to first write the temporary LSL configuration file
     from mne_lsl.player import PlayerLSL
 
-    with PlayerLSL(raw_sinusoids, name=f"P_{request.node.name}") as player:
+    with PlayerLSL(
+        raw_sinusoids, name=f"P_{request.node.name}", chunk_size=200
+    ) as player:
         yield player
 
 

--- a/mne_lsl/stream/tests/test_stream_lsl.py
+++ b/mne_lsl/stream/tests/test_stream_lsl.py
@@ -513,7 +513,7 @@ def _player_mock_lsl_stream_int(
     data = np.full((5, 1000), np.arange(5).reshape(-1, 1))
     raw = RawArray(data, create_info(5, 1000, "eeg"))
 
-    player = PlayerLSL(raw, chunk_size=chunk_size, name=f"P_{request.node.name}")
+    player = PlayerLSL(raw, chunk_size=chunk_size, name=name)
     player.start()
     info.update(player.info)
     status.value = 1

--- a/mne_lsl/utils/logs.py
+++ b/mne_lsl/utils/logs.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # c.f. PEP 563, PEP 649
 
 import inspect
 import logging
+import os
 from functools import wraps
 from importlib import import_module
 from pathlib import Path
@@ -21,7 +22,12 @@ _PACKAGE: str = __package__.split(".")[0]
 
 
 @fill_doc
-def _init_logger(*, verbose: Optional[Union[bool, str, int]] = None) -> Logger:
+def _init_logger(
+    *,
+    verbose: Optional[Union[bool, str, int]] = os.getenv(
+        "MNE_LSL_LOG_LEVEL", "WARNING"
+    ),
+) -> Logger:
     """Initialize a logger.
 
     Assigns sys.stdout as the first handler of the logger.

--- a/tutorials/00_introduction.py
+++ b/tutorials/00_introduction.py
@@ -96,7 +96,7 @@ set_log_level("WARNING")
 # %%
 
 fname = sample.data_path() / "sample-ant-raw.fif"
-player = Player(fname).start()
+player = Player(fname, chunk_size=200).start()
 player.info
 
 # %%
@@ -107,10 +107,10 @@ player.info
 #
 # .. note::
 #
-#     The default setting for chunk_size is ``64``, which helps prevent overly frequent
-#     data transmission and minimizes CPU utilization. Nonetheless, in real-time
-#     applications, there may be advantages to employing smaller chunk sizes for data
-#     publication.
+#     The default setting for chunk_size is ``10``. In real-time applications, there may
+#     be advantages to employing smaller chunk sizes for data publication, but to build
+#     the documentation website or to run test successfully on CIs, a larger chunk size
+#     is used to reduce the number of push operations and improve stability.
 
 sfreq = player.info["sfreq"]
 chunk_size = player.chunk_size


### PR DESCRIPTION
Instead of single-use thread which can have overhead at creation/destruction and likely leaves some resources that don't get garbage collected, let's use a pool with a single worker. It should improve stability and reduce overhead. At the same time, let's stabilize further the test by forcing the player to run in child process and by increasing the chunk size to 200.

Closes #261 
Closes #260 