### PR TITLE
Revert "Rm use of custom sphinx-remove-toctrees (#240)"

### DIFF
--- a/doc/_sphinxext/sphinx_remove_toctrees.py
+++ b/doc/_sphinxext/sphinx_remove_toctrees.py
@@ -1,0 +1,43 @@
+"""A small sphinx extension to remove toctrees."""
+
+from pathlib import Path
+
+from sphinx import addnodes
+
+
+def remove_toctrees(app, env):
+    """Remove toctrees from pages a user provides.
+
+    This happens at the end of the build process, so even though the toctrees
+    are removed, it won't raise sphinx warnings about un-referenced pages.
+    """
+    patterns = app.config.remove_from_toctrees
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    # figure out the list of patterns to remove from all toctrees
+    to_remove = []
+    for pattern in patterns:
+        # inputs should either be a glob pattern or a direct path so just use glob
+        srcdir = Path(env.srcdir)
+        for matched in srcdir.glob(pattern):
+            to_remove.append(
+                str(matched.relative_to(srcdir).with_suffix("").as_posix())
+            )
+    # loop through all tocs and remove the ones that match our pattern
+    for _, tocs in env.tocs.items():
+        for toctree in tocs.traverse(addnodes.toctree):
+            new_entries = []
+            for entry in toctree.attributes.get("entries", []):
+                if entry[1] not in to_remove:
+                    new_entries.append(entry)
+            # if there are no more entries just remove the toctree
+            if len(new_entries) == 0:
+                toctree.parent.remove(toctree)
+            else:
+                toctree.attributes["entries"] = new_entries
+
+
+def setup(app):  # noqa: D103
+    app.add_config_value("remove_from_toctrees", [], "html")
+    app.connect("env-updated", remove_toctrees)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,6 +18,8 @@ from sphinx_gallery.sorting import FileNameSortKey
 
 import mne_lsl
 
+# -- path setup ------------------------------------------------------------------------
+sys.path.append(str(Path(__file__).parent / "_sphinxext"))
 
 # -- project information ---------------------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -58,6 +60,7 @@ extensions = [
     "sphinx_design",
     "sphinx_gallery.gen_gallery",
     "sphinx_issues",
+    # local extensions
     "sphinx_remove_toctrees",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ doc = [
   'sphinx-design',
   'sphinx-gallery',
   'sphinx-issues',
-  'sphinx-remove-toctrees',
   'sphinxcontrib-bibtex',
 ]
 full = ['mne_lsl[all]']


### PR DESCRIPTION
This reverts commit dfdaee1eb0e2283018c5f4aa393498029000fbd1.
Fix the documentation build.

Reported in https://github.com/executablebooks/sphinx-remove-toctrees/issues/9