### PR TITLE
Drop isort and pydocstyle in favor of ruff and pin to 0.6.0 and above

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-    - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            files: mne_lsl
-
     - repo: https://github.com/astral-sh/ruff-pre-commit
       rev: v0.6.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
           - id: ruff
             name: ruff linter
             args: [--fix, --show-fixes]
-            files: mne_lsl
           - id: ruff-format
             name: ruff formatter
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,6 @@ repos:
             files: mne_lsl
           - id: ruff-format
             name: ruff formatter
-            files: mne_lsl
 
     - repo: https://github.com/codespell-project/codespell
       rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,6 @@ repos:
             args: [--write-changes]
             additional_dependencies: [tomli]
 
-    - repo: https://github.com/pycqa/pydocstyle
-      rev: 6.3.0
-      hooks:
-          - id: pydocstyle
-            files: mne_lsl
-            additional_dependencies: [tomli]
-
     - repo: https://github.com/mscheltienne/bibclean
       rev: 0.8.0
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
             files: mne_lsl
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.5.7
+      rev: v0.6.0
       hooks:
           - id: ruff
             name: ruff linter

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ sys.path.append(str(Path(__file__).parent / "_sphinxext"))
 
 project = "MNE-LSL"
 author = "M. Scheltienne, A. Desvachez, K. Lee"
-copyright = f"{date.today().year}, {author}"
+copyright = f"{date.today().year}, {author}"  # noqa: A001
 release = mne_lsl.__version__
 package = mne_lsl.__name__
 gh_url = "https://github.com/mne-tools/mne-lsl"

--- a/examples/00_player_separate_process.py
+++ b/examples/00_player_separate_process.py
@@ -28,7 +28,6 @@ from mne.io import read_raw_fif
 from mne_lsl.datasets import sample
 from mne_lsl.player import PlayerLSL as Player
 
-
 raw = read_raw_fif(sample.data_path() / "sample-ecg-raw.fif", preload=False)
 raw.crop(0, 3).load_data()
 player = Player(raw, chunk_size=200, n_repeat=1, name="example-process")

--- a/examples/10_peak_detection.py
+++ b/examples/10_peak_detection.py
@@ -165,10 +165,10 @@ plt.show()
 from time import sleep
 
 import numpy as np
-from mne_lsl.stream import StreamLSL
 from numpy.typing import NDArray
 from scipy.signal import find_peaks
 
+from mne_lsl.stream import StreamLSL
 
 ECG_HEIGHT: float = 98.0  # percentile height constraint, in %
 ECG_DISTANCE: float = 0.5  # distance constraint, in seconds
@@ -253,10 +253,10 @@ class Detector:
 from time import sleep
 
 import numpy as np
-from mne_lsl.stream import StreamLSL
 from numpy.typing import NDArray
 from scipy.signal import find_peaks
 
+from mne_lsl.stream import StreamLSL
 
 ECG_HEIGHT: float = 98.0  # percentile height constraint, in %
 ECG_DISTANCE: float = 0.5  # distance constraint, in seconds

--- a/examples/40_decode.py
+++ b/examples/40_decode.py
@@ -19,8 +19,8 @@ from matplotlib import pyplot as plt
 from mne.decoding import Vectorizer
 from mne.io import read_raw_fif
 from sklearn.linear_model import LogisticRegression
-from sklearn.pipeline import Pipeline
 from sklearn.model_selection import ShuffleSplit, cross_val_score
+from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import StandardScaler
 
 from mne_lsl.datasets import sample

--- a/mne_lsl/commands/main.py
+++ b/mne_lsl/commands/main.py
@@ -8,8 +8,8 @@ from .viewer import run as viewer
 
 
 @click.group()
-def run() -> None:  # noqa: D401
-    """Main package entry-point."""
+def run() -> None:
+    """Main package entry-point."""  # noqa: D401
 
 
 run.add_command(player)

--- a/mne_lsl/conftest.py
+++ b/mne_lsl/conftest.py
@@ -108,7 +108,7 @@ def _closer():
     outlets.clear()
 
 
-@pytest.fixture()
+@pytest.fixture
 def close_io():
     """Return function that will close inlets and outlets if present."""
     return _closer
@@ -127,13 +127,13 @@ def fname(tmp_path_factory) -> Path:
     return fname_mod
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw(fname: Path) -> BaseRaw:
     """Return the raw file corresponding to fname."""
     return read_raw_fif(fname, preload=True)
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_annotations(raw: BaseRaw) -> BaseRaw:
     """Return a raw file with annotations."""
     annotations = Annotations(

--- a/mne_lsl/datasets/tests/test_fetch.py
+++ b/mne_lsl/datasets/tests/test_fetch.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from typing import Optional
 
 
-@pytest.fixture()
+@pytest.fixture
 def license_file() -> Optional[Path]:
     """Find the license file if present."""
     fname = Path(__file__).parent.parent.parent.parent / "LICENSE"
@@ -22,7 +22,7 @@ def license_file() -> Optional[Path]:
         pytest.skip("License file not found.")
 
 
-@pytest.fixture()
+@pytest.fixture
 def license_url() -> str:
     """Return the URL for the license file."""
     return "https://raw.githubusercontent.com/mne-tools/mne-lsl/main/"

--- a/mne_lsl/lsl/_utils.py
+++ b/mne_lsl/lsl/_utils.py
@@ -55,15 +55,15 @@ class XMLElement:
         return XMLElement(lib.lsl_parent(self.e))
 
     # -- Content Queries ------------------------------------------------------
-    def empty(self):  # noqa: D401
-        """True if this node is empty."""
+    def empty(self):
+        """True if this node is empty."""  # noqa: D401
         return bool(lib.lsl_empty(self.e))
 
-    def is_text(self):  # noqa: D401
+    def is_text(self):
         """True if this node is a text body (instead of an XML element).
 
         True both for plain char data and CData.
-        """
+        """  # noqa: D401
         return bool(lib.lsl_is_text(self.e))
 
     def name(self):
@@ -87,26 +87,26 @@ class XMLElement:
         return res.decode("utf-8")
 
     # -- Modification ---------------------------------------------------------
-    def append_child_value(self, name, value):  # noqa: D205, D400
+    def append_child_value(self, name, value):
         """Append a child node with a given name, which has a (nameless) plain-text
         child with the given text value.
-        """
+        """  # noqa: D205, D400
         return XMLElement(
             lib.lsl_append_child_value(self.e, str.encode(name), str.encode(value))
         )
 
-    def prepend_child_value(self, name, value):  # noqa: D205, D400
+    def prepend_child_value(self, name, value):
         """Prepend a child node with a given name, which has a (nameless) plain-text
         child with the given text value.
-        """
+        """  # noqa: D205, D400
         return XMLElement(
             lib.lsl_prepend_child_value(self.e, str.encode(name), str.encode(value))
         )
 
-    def set_child_value(self, name, value):  # noqa: D205, D400
-        """Set the text value of the (nameless) plain-text child of a named
-        child node.
-        """
+    def set_child_value(self, name, value):
+        """Set the text value of the (nameless) plain-text child of a named child
+        node.
+        """  # noqa: D205, D400
         return XMLElement(
             lib.lsl_set_child_value(self.e, str.encode(name), str.encode(value))
         )

--- a/mne_lsl/lsl/_utils.pyi
+++ b/mne_lsl/lsl/_utils.pyi
@@ -72,8 +72,8 @@ class XMLElement:
         """
 
     def set_child_value(self, name, value):
-        """Set the text value of the (nameless) plain-text child of a named
-        child node.
+        """Set the text value of the (nameless) plain-text child of a named child
+        node.
         """
 
     def set_name(self, name):

--- a/mne_lsl/lsl/tests/test_functions.py
+++ b/mne_lsl/lsl/tests/test_functions.py
@@ -36,7 +36,7 @@ def test_local_clock():
 
 
 @pytest.mark.xfail(reason="Fails if streams are present in the background.")
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_resolve_streams():
     """Test detection of streams on the network."""
     streams = resolve_streams(timeout=0.1)

--- a/mne_lsl/lsl/tests/test_load_liblsl.py
+++ b/mne_lsl/lsl/tests/test_load_liblsl.py
@@ -67,7 +67,7 @@ def download_liblsl_outdated(tmp_path_factory) -> Path:
     return Path(libpath)
 
 
-@pytest.fixture()
+@pytest.fixture
 def liblsl_outdated(tmp_path, download_liblsl_outdated) -> Path:
     """Fixture to provide an outdated liblsl version."""
     copy(download_liblsl_outdated, tmp_path / download_liblsl_outdated.name)

--- a/mne_lsl/lsl/tests/test_stream_outlet.py
+++ b/mne_lsl/lsl/tests/test_stream_outlet.py
@@ -158,7 +158,7 @@ def test_invalid_outlet():
         StreamOutlet(sinfo, max_buffered=-101)
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ("dtype_str", "dtype"),
     [
@@ -221,7 +221,7 @@ def test_push_chunk_timestamps(dtype_str, dtype, close_io):
     close_io()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_push_chunk_irregularly_sampled_stream(close_io):
     """Test pushing a chunk on an irregularly sampled stream."""
     x = np.array([[1, 4], [2, 5], [3, 6]], dtype=np.float32)

--- a/mne_lsl/player/_base.py
+++ b/mne_lsl/player/_base.py
@@ -17,9 +17,9 @@ elif check_version("mne", "1.5"):
     from mne.io.meas_info import ContainsMixin, SetChannelsMixin
     from mne.io.pick import _picks_to_idx
 else:
+    from mne.channels.channels import SetChannelsMixin
     from mne.io.meas_info import ContainsMixin
     from mne.io.pick import _picks_to_idx
-    from mne.channels.channels import SetChannelsMixin
 
 from ..utils._checks import check_type, ensure_int, ensure_path
 from ..utils._docs import fill_doc

--- a/mne_lsl/player/tests/test_player_lsl.py
+++ b/mne_lsl/player/tests/test_player_lsl.py
@@ -212,7 +212,7 @@ def _create_inlet(name: str, source_id: str) -> StreamInlet:
     return inlet
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream(fname: Path, chunk_size, request):
     """Create a mock LSL stream for testing."""
     # nest the PlayerLSL import to first write the temporary LSL configuration file
@@ -227,7 +227,7 @@ def mock_lsl_stream(fname: Path, chunk_size, request):
         yield player
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_unit(mock_lsl_stream, raw, close_io):
     """Test getting and setting the player channel units."""
     player = mock_lsl_stream
@@ -270,7 +270,7 @@ def test_player_unit(mock_lsl_stream, raw, close_io):
     player.stop()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_rename_channels(mock_lsl_stream, raw, close_io):
     """Test channel renaming."""
     player = mock_lsl_stream
@@ -306,7 +306,7 @@ def test_player_rename_channels(mock_lsl_stream, raw, close_io):
     player.stop()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_set_channel_types(mock_lsl_stream, raw, close_io):
     """Test channel type setting."""
     player = mock_lsl_stream
@@ -388,7 +388,7 @@ def test_player_set_meas_date(fname, chunk_size, request):
     player.stop()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_annotations(raw_annotations, close_io, chunk_size, request):
     """Test player with annotations."""
     name = f"P_{request.node.name}"
@@ -457,7 +457,7 @@ def test_player_annotations(raw_annotations, close_io, chunk_size, request):
     player.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_annotations_1000_samples() -> BaseRaw:
     """Return a 1000 sample raw object with annotations."""
     n_samples = 1000
@@ -475,7 +475,7 @@ def raw_annotations_1000_samples() -> BaseRaw:
     return raw.drop_channels("trg").set_annotations(annotations)
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_annotations_multiple_of_chunk_size(
     raw_annotations_1000_samples, chunk_size, request
 ):
@@ -501,7 +501,7 @@ def test_player_annotations_multiple_of_chunk_size(
     player.stop()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_player_n_repeat(raw, chunk_size, request):
     """Test argument 'n_repeat'."""
     name = f"P_{request.node.name}"

--- a/mne_lsl/stream/tests/test_epochs.py
+++ b/mne_lsl/stream/tests/test_epochs.py
@@ -144,7 +144,7 @@ def test_ensure_detrend_str():
         _ensure_detrend_str(5.5)
 
 
-@pytest.fixture()
+@pytest.fixture
 def stim_channels_events() -> NDArray[np.int64]:
     """An event array that will be added to a set of stimulation channels."""
     return np.array(
@@ -161,7 +161,7 @@ def stim_channels_events() -> NDArray[np.int64]:
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def stim_channels(stim_channels_events: NDArray[np.int64]) -> NDArray[np.float64]:
     """A set of stimulation channels of shape (n_channels, n_samples)."""
     channels = np.zeros((2, 100))
@@ -188,7 +188,7 @@ def test_find_events_in_stim_channels(
         )
 
 
-@pytest.fixture()
+@pytest.fixture
 def events() -> NDArray[np.int64]:
     """Return a simple event array.
 
@@ -244,7 +244,7 @@ def test_prune_events(events: NDArray[np.int64]):
     assert_allclose(events_[:, 0], np.arange(20, 20 * (events_[:, 0].size + 1), 20) + 1)
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_with_stim_channel() -> BaseRaw:
     """Create a raw object with a stimulation channel.
 
@@ -266,6 +266,8 @@ def raw_with_stim_channel() -> BaseRaw:
 
 
 class DummyPlayer:
+    """Dummy player object containing the player attributes."""
+
     def __init__(self, /, **kwargs):
         self.__dict__.update(kwargs)
 
@@ -289,7 +291,7 @@ def _player_mock_lsl_stream(
     player.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream(raw_with_stim_channel, request, chunk_size):
     """Create a mock LSL stream streaming events on a stim channel."""
     manager = mp.Manager()
@@ -414,7 +416,7 @@ def test_epochs_without_event_stream_manual_acquisition(mock_lsl_stream):
     stream.disconnect()
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_ones() -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Data array used for baseline correction test."""
     data = np.ones((2, 100, 5), dtype=np.float64)
@@ -529,7 +531,7 @@ def test_process_data_detrend_constant(
     assert_allclose(data, np.zeros(data.shape))
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_detrend_linear() -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """Data array used for detrending test."""
     data = [
@@ -589,7 +591,7 @@ def test_process_data_flat(data_ones: tuple[NDArray[np.float64], NDArray[np.floa
     assert data.shape[0] == 0
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_reject():
     """Data array used for rejection test."""
     data = np.ones((2, 100, 5), dtype=np.float64)
@@ -644,7 +646,7 @@ def test_process_data_reject(
     assert data.shape[0] == 0
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_reject_tmin_tmax():
     """Data array used for rejection based on segment test."""
     data = np.ones((2, 100, 5), dtype=np.float64)
@@ -687,7 +689,7 @@ def test_process_data_reject_tmin_tmax(
     assert data.shape[0] == 1
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_with_annotations(raw_with_stim_channel: BaseRaw) -> BaseRaw:
     """Create a raw object with annotations instead of a stim channel.
 
@@ -710,7 +712,7 @@ def raw_with_annotations(raw_with_stim_channel: BaseRaw) -> BaseRaw:
     return raw_with_stim_channel.drop_channels("trg").set_annotations(annotations)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream_with_annotations(raw_with_annotations, request, chunk_size):
     """Create a mock LSL stream streaming events with annotations."""
     manager = mp.Manager()
@@ -793,7 +795,7 @@ def test_remove_empty_elements():
     assert ts.size == 4
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_with_annotations_and_first_samp() -> BaseRaw:
     """Raw with annotations and first_samp set."""
     fname = testing.data_path() / "mne-sample" / "sample_audvis_raw.fif"
@@ -811,7 +813,7 @@ def raw_with_annotations_and_first_samp() -> BaseRaw:
     return raw
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream_with_annotations_and_first_samp(
     raw_with_annotations_and_first_samp, request, chunk_size
 ):
@@ -833,7 +835,7 @@ def mock_lsl_stream_with_annotations_and_first_samp(
     process.kill()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 @pytest.mark.timeout(30)  # takes under 9s locally
 def test_epochs_with_irregular_numerical_event_stream_and_first_samp(
     mock_lsl_stream_with_annotations_and_first_samp,

--- a/mne_lsl/stream/tests/test_stream_lsl.py
+++ b/mne_lsl/stream/tests/test_stream_lsl.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 
 class DummyPlayer:
+    """Dummy player object containing the player attributes."""
+
     def __init__(self, /, **kwargs):
         self.__dict__.update(kwargs)
 
@@ -65,7 +67,7 @@ def _player_mock_lsl_stream(
     player.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream(fname, request, chunk_size):
     """Create a mock LSL stream for testing."""
     manager = mp.Manager()
@@ -102,7 +104,7 @@ def _sleep_until_new_data(acq_delay, player):
     time.sleep(factor * max(acq_delay, player.chunk_size / player.info["sfreq"]))
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream(mock_lsl_stream, acquisition_delay, raw):
     """Test a valid Stream."""
     # test connect/disconnect
@@ -150,7 +152,7 @@ def test_stream(mock_lsl_stream, acquisition_delay, raw):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_invalid():
     """Test creation and connection to an invalid stream."""
     stream = Stream(bufsize=2, name="101")
@@ -208,7 +210,7 @@ def test_stream_double_connection(mock_lsl_stream):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_drop_channels(mock_lsl_stream, acquisition_delay, raw):
     """Test dropping channels."""
     stream = Stream(
@@ -254,7 +256,7 @@ def test_stream_drop_channels(mock_lsl_stream, acquisition_delay, raw):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_pick(mock_lsl_stream, acquisition_delay, raw):
     """Test channel selection."""
     stream = Stream(
@@ -420,7 +422,7 @@ def test_stream_channel_units(mock_lsl_stream, raw):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_add_reference_channels(mock_lsl_stream, acquisition_delay, raw):
     """Test add reference channels and channel selection."""
     stream = Stream(
@@ -487,7 +489,7 @@ def test_stream_repr(mock_lsl_stream):
     assert stream.__repr__() == "<Stream: OFF | (source: test)>"
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_get_data_picks(mock_lsl_stream, acquisition_delay, raw):
     """Test channel sub-selection when getting data."""
     stream = Stream(
@@ -513,7 +515,7 @@ def test_stream_get_data_picks(mock_lsl_stream, acquisition_delay, raw):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_n_new_samples(mock_lsl_stream, caplog):
     """Test the number of new samples available."""
     stream = Stream(
@@ -572,7 +574,7 @@ def _player_mock_lsl_stream_int(
     (player.chunk_size / player.info["sfreq"])
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream_int(request, chunk_size):
     """Create a mock LSL stream streaming the channel number continuously."""
     manager = mp.Manager()
@@ -595,7 +597,7 @@ def mock_lsl_stream_int(request, chunk_size):
     process.kill()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_rereference(mock_lsl_stream_int, acquisition_delay):
     """Test re-referencing an EEG-like stream."""
     stream = Stream(
@@ -768,7 +770,7 @@ def _player_mock_lsl_stream_annotations(
     player.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream_annotations(raw_annotations, request, chunk_size):
     """Create a mock LSL stream streaming the channel number continuously."""
     manager = mp.Manager()
@@ -788,7 +790,7 @@ def mock_lsl_stream_annotations(raw_annotations, request, chunk_size):
     process.kill()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_annotations_picks(mock_lsl_stream_annotations):
     """Test sub-selection of annotations."""
     stream = (
@@ -806,7 +808,7 @@ def test_stream_annotations_picks(mock_lsl_stream_annotations):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_filter_deletion(mock_lsl_stream, caplog):
     """Test deletion of filters applied to a Stream."""
     # test no filter
@@ -865,7 +867,7 @@ def test_stream_filter_deletion(mock_lsl_stream, caplog):
     stream.disconnect()
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_sinusoids() -> BaseRaw:
     """Create a raw object with sinusoids."""
     times = np.arange(0, 2, 1 / 1000)
@@ -900,7 +902,7 @@ def _player_mock_lsl_stream_sinusoids(
     player.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_lsl_stream_sinusoids(raw_sinusoids, request, chunk_size):
     """Create a mock LSL stream streaming sinusoids."""
     manager = mp.Manager()
@@ -921,7 +923,7 @@ def mock_lsl_stream_sinusoids(raw_sinusoids, request, chunk_size):
     process.kill()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_filter(mock_lsl_stream_sinusoids, raw_sinusoids):
     """Test stream filters."""
     freqs = fftfreq(raw_sinusoids.times.size, 1 / raw_sinusoids.info["sfreq"])
@@ -1019,7 +1021,7 @@ def test_stream_filter(mock_lsl_stream_sinusoids, raw_sinusoids):
     stream.disconnect()
 
 
-@pytest.mark.slow()
+@pytest.mark.slow
 def test_stream_notch_filter(mock_lsl_stream_sinusoids, raw_sinusoids):
     """Test stream notch filters."""
     freqs = fftfreq(raw_sinusoids.times.size, 1 / raw_sinusoids.info["sfreq"])

--- a/mne_lsl/stream_viewer/backends/_backend.py
+++ b/mne_lsl/stream_viewer/backends/_backend.py
@@ -36,9 +36,7 @@ class _Backend(ABC):
         self._selected_channels = copy.deepcopy(self._scope.selected_channels)
 
     def _init_variables(self):  # noqa
-        """
-        Initialize variables depending on xRange, yRange and selected_channels.
-        """
+        """Initialize variables depending on xRange, yRange and selected_channels."""
         logger.debug("Initialization of variables..")
 
         # xRange
@@ -50,10 +48,9 @@ class _Backend(ABC):
     # ------------------------ Trigger Events ----------------------
     @abstractmethod
     def _update_LPT_trigger_events(self, trigger_arr):  # noqa
-        """
-        Check if new LPT events (on the trigger channel) have entered the
-        buffer. New events are added to self._trigger_events and displayed
-        if needed.
+        """Check if new LPT events (on the trigger channel) have entered the buffer.
+
+        New events are added to self._trigger_events and displayed if needed.
         """
 
     def _clean_up_trigger_events(self):
@@ -69,10 +66,7 @@ class _Backend(ABC):
 
     @abstractmethod
     def _update_loop(self, *args, **kwargs):  # noqa
-        """
-        Main update loop retrieving data from the scope's buffer and updating
-        the Canvas.
-        """
+        """Update loop retrieving data from the buffer and updating the Canvas."""
         self._scope.update_loop()
 
     # --------------------------- Events ---------------------------
@@ -83,10 +77,9 @@ class _Backend(ABC):
     # --------------------------------------------------------------------
     @property
     def scope(self):
-        """
-        Scope connected to an Inlet acquiring the data and applying
-        filtering. The scope has a buffer of BUFFER_DURATION seconds
-        (default: 30s).
+        """Scope connected to an Inlet acquiring the data and applying filtering.
+
+        The scope has a buffer of BUFFER_DURATION seconds (default: 30s).
         """
         return self._scope
 
@@ -98,10 +91,7 @@ class _Backend(ABC):
     @xRange.setter
     @abstractmethod
     def xRange(self, xRange):
-        """
-        Called when the user changes the X-axis range/scale, i.e. the duration
-        of the plotting window.
-        """
+        """Called when the user changes the X-axis range/scale."""
 
     @property
     def yRange(self):
@@ -131,10 +121,7 @@ class _Backend(ABC):
     @show_LPT_trigger_events.setter
     @abstractmethod
     def show_LPT_trigger_events(self, show_LPT_trigger_events):
-        """
-        Called when the user ticks or untick the show_LPT_trigger_events
-        box.
-        """
+        """Called when the user ticks or untick the show_LPT_trigger_events box."""
 
 
 @fill_doc

--- a/mne_lsl/stream_viewer/scope/_scope.py
+++ b/mne_lsl/stream_viewer/scope/_scope.py
@@ -37,10 +37,7 @@ class _Scope(ABC):
     # -------------------------- Main Loop -------------------------
     @abstractmethod
     def update_loop(self):  # noqa
-        """
-        Main update loop acquiring data from the LSL stream and filling the
-        scope's buffer.
-        """
+        """Update loop acquiring data from the stream and filling the scope's buffer."""
 
     @abstractmethod
     def _read_lsl_stream(self):

--- a/mne_lsl/stream_viewer/scope/scope_eeg.py
+++ b/mne_lsl/stream_viewer/scope/scope_eeg.py
@@ -132,10 +132,7 @@ class ScopeEEG(_Scope):
             self._data_acquired -= car_ch.reshape((-1, 1))
 
     def _filter_trigger(self, tol=0.05):  # noqa
-        """
-        Cleans up the trigger signal by removing successive duplicates of a
-        trigger value.
-        """
+        """Remove successive duplicates of a trigger value."""
         self._trigger_acquired[
             np.abs(np.diff(self._trigger_acquired, prepend=[0])) <= tol
         ] = 0
@@ -143,16 +140,16 @@ class ScopeEEG(_Scope):
     # --------------------------------------------------------------------
     @property
     def channels_labels(self):
-        """
-        List of the channel labels present in the connected stream.
+        """List of the channel labels present in the connected stream.
+
         The TRIGGER channel is removed.
         """
         return self._channels_labels
 
     @property
     def nb_channels(self):
-        """
-        Number of channels present in the connected stream.
+        """Number of channels present in the connected stream.
+
         The TRIGGER channel is removed.
         """
         return self._nb_channels

--- a/mne_lsl/stream_viewer/stream_viewer.py
+++ b/mne_lsl/stream_viewer/stream_viewer.py
@@ -50,10 +50,7 @@ class StreamViewer:
     # --------------------------------------------------------------------
     @staticmethod
     def _check_stream_name(stream_name):  # noqa
-        """
-        Check that the stream_name is valid or search for a valid stream on
-        the network.
-        """
+        """Check that the name is valid or search for a valid stream on the network."""
         check_type(stream_name, (None, str), item_name="stream_name")
         streams = resolve_streams(name=stream_name)
         if len(streams) == 0:

--- a/mne_lsl/utils/tests/test_meas_info.py
+++ b/mne_lsl/utils/tests/test_meas_info.py
@@ -1,5 +1,3 @@
-"""Test meas_info.py"""
-
 import uuid
 
 import pytest

--- a/mne_lsl/utils/tests/test_test.py
+++ b/mne_lsl/utils/tests/test_test.py
@@ -6,8 +6,9 @@ from mne_lsl.datasets import testing
 from mne_lsl.utils._tests import compare_infos, match_stream_and_raw_data
 
 
-@pytest.fixture()
+@pytest.fixture
 def raw_without_samples():
+    """Raw EEG data."""
     fname = testing.data_path() / "sample-eeg-ant-raw.fif"
     return read_raw_fif(fname, preload=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,11 +82,10 @@ doc = [
   'sphinxcontrib-bibtex',
 ]
 full = ['mne_lsl[all]']
-stubs = ['isort', 'mypy', 'ruff>=0.6.0']
+stubs = ['mypy', 'ruff>=0.6.0']
 style = [
   'bibclean',
   'codespell[toml]>=2.2.4',
-  'isort',
   'pre-commit',
   'ruff>=0.6.0',
   'toml-sort',
@@ -131,20 +130,6 @@ omit = [
   '**/tests/**',
 ]
 
-[tool.isort]
-extend_skip_glob = [
-  '.github/*',
-  'doc/*',
-  'examples/*',
-  'pyproject.toml',
-  'setup.py',
-  'tutorials/*',
-]
-line_length = 88
-multi_line_output = 3
-profile = 'black'
-py_version = 39
-
 [tool.pytest.ini_options]
 addopts = ['--color=yes', '--cov-report=', '--durations=20', '--junit-xml=junit-results.xml', '--strict-config', '--tb=short', '-ra', '-v']
 junit_family = 'xunit2'
@@ -165,7 +150,7 @@ line-ending = "lf"
 
 [tool.ruff.lint]
 ignore = []
-select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
+select = ['A', 'B', 'D', 'E', 'F', 'G', 'I', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,12 +175,12 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 
   'D107', # undocumented public init
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
-'*.pyi' = ['E501', 'F811']
+'*.pyi' = ['D', 'E501', 'F811']
 '__init__.py' = ['F401']
 '*/stream_viewer/backends/*' = ['D401']
 '*/tests/*' = ['D401']
-'examples/*' = ['B018', 'E402', 'F811', 'T201']
-'tutorials/*' = ['B018', 'E402', 'F811', 'T201']
+'examples/*' = ['B018', 'D205', 'D400', 'E402', 'F811', 'T201']
+'tutorials/*' = ['B018', 'D205', 'D400', 'E402', 'F811', 'T201']
 
 [tool.ruff.lint.pydocstyle]
 convention = 'numpy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,12 +136,7 @@ junit_family = 'xunit2'
 minversion = '8.0'
 
 [tool.ruff]
-extend-exclude = [
-  '.github/*',
-  'doc/*',
-  'pyproject.toml',
-  'setup.py',
-]
+extend-exclude = []
 line-length = 88
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 
 '*.pyi' = ['E501', 'F811']
 '__init__.py' = ['F401']
 '*/stream_viewer/backends/*' = ['D401']
+'*/tests/*' = ['D401']
 'examples/*' = ['B018', 'E402', 'F811', 'T201']
 'tutorials/*' = ['B018', 'E402', 'F811', 'T201']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,13 +82,13 @@ doc = [
   'sphinxcontrib-bibtex',
 ]
 full = ['mne_lsl[all]']
-stubs = ['isort', 'mypy', 'ruff>=0.1.8']
+stubs = ['isort', 'mypy', 'ruff>=0.5.4']
 style = [
   'bibclean',
   'codespell[toml]>=2.2.4',
   'isort',
-  'pydocstyle[toml]',
-  'ruff>=0.1.8',
+  'pre-commit',
+  'ruff>=0.5.4',
   'toml-sort',
   'yamllint',
 ]
@@ -145,13 +145,6 @@ multi_line_output = 3
 profile = 'black'
 py_version = 39
 
-[tool.pydocstyle]
-add_ignore = 'D100,D104,D107'
-convention = 'numpy'
-ignore-decorators = '(copy_doc|property|.*setter|.*getter|pyqtSlot|Slot)'
-match = '^(?!setup|__init__|test_|_typing).*\.py'
-match-dir = '^mne_lsl.*'
-
 [tool.pytest.ini_options]
 addopts = ['--color=yes', '--cov-report=', '--durations=20', '--junit-xml=junit-results.xml', '--strict-config', '--tb=short', '-ra', '-v']
 junit_family = 'xunit2'
@@ -172,17 +165,25 @@ line-ending = "lf"
 
 [tool.ruff.lint]
 ignore = []
-select = ['A', 'B', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
+select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [
   'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
+  'D100', # undocumented public module
+  'D104', # undocumented public package
+  'D107', # undocumented public init
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
 '*.pyi' = ['E501', 'F811']
 '__init__.py' = ['F401']
+'*/stream_viewer/backends/*' = ['D401']
 'examples/*' = ['B018', 'E402', 'F811', 'T201']
 'tutorials/*' = ['B018', 'E402', 'F811', 'T201']
+
+[tool.ruff.lint.pydocstyle]
+convention = 'numpy'
+ignore-decorators = ["mne_lsl.utils._docs.copy_doc", "qtpy.QtCore.Slot"]
 
 [tool.setuptools]
 include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,13 +82,13 @@ doc = [
   'sphinxcontrib-bibtex',
 ]
 full = ['mne_lsl[all]']
-stubs = ['isort', 'mypy', 'ruff>=0.5.4']
+stubs = ['isort', 'mypy', 'ruff>=0.6.0']
 style = [
   'bibclean',
   'codespell[toml]>=2.2.4',
   'isort',
   'pre-commit',
-  'ruff>=0.5.4',
+  'ruff>=0.6.0',
   'toml-sort',
   'yamllint',
 ]
@@ -176,9 +176,9 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'LOG', 'NPY', 'PIE', 'PT', 'T20', 'UP', 
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
 '*.pyi' = ['D', 'E501', 'F811']
-'__init__.py' = ['F401']
 '*/stream_viewer/backends/*' = ['D401']
 '*/tests/*' = ['D401']
+'__init__.py' = ['F401']
 'examples/*' = ['B018', 'D205', 'D400', 'E402', 'F811', 'T201']
 'tutorials/*' = ['B018', 'D205', 'D400', 'E402', 'F811', 'T201']
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,9 +155,9 @@ select = ['A', 'B', 'D', 'E', 'F', 'G', 'I', 'LOG', 'NPY', 'PIE', 'PT', 'T20', '
 [tool.ruff.lint.per-file-ignores]
 '*' = [
   'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
-  'D100', # undocumented public module
-  'D104', # undocumented public package
-  'D107', # undocumented public init
+  'D100', # 'Missing docstring in public module'
+  'D104', # 'Missing docstring in public package'
+  'D107', # 'Missing docstring in __init__'
   'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
 '*.pyi' = ['D', 'E501', 'F811']

--- a/tools/stubgen.py
+++ b/tools/stubgen.py
@@ -4,7 +4,6 @@ import sys
 from importlib import import_module
 from pathlib import Path
 
-import isort
 from mypy import stubgen
 
 import mne_lsl
@@ -35,7 +34,6 @@ stubgen.main(
 )
 stubs = list(directory.rglob("*.pyi"))
 config = str(directory.parent / "pyproject.toml")
-config_isort = isort.settings.Config(config)
 
 # expand docstrings and inject into stub files
 for stub in stubs:
@@ -61,9 +59,12 @@ for stub in stubs:
                 method.body[0].value.value = docstring
     unparsed = ast.unparse(module_ast)
     stub.write_text(unparsed, encoding="utf-8")
-    # sort imports
-    isort.file(stub, config=config_isort)
 
 # run ruff to improve stub style
+execution = subprocess.run(
+    ["ruff", "check", str(directory), "--fix", "--config", config]
+)
+if execution.returncode:
+    sys.exit(execution.returncode)
 execution = subprocess.run(["ruff", "format", str(directory), "--config", config])
 sys.exit(execution.returncode)

--- a/tools/stubgen.py
+++ b/tools/stubgen.py
@@ -62,7 +62,7 @@ for stub in stubs:
 
 # run ruff to improve stub style
 execution = subprocess.run(
-    ["ruff", "check", str(directory), "--fix", "--config", config]
+    ["ruff", "check", str(directory), "--fix", "--unsafe-fixes", "--config", config]
 )
 if execution.returncode:
     sys.exit(execution.returncode)

--- a/tutorials/20_player_annotations.py
+++ b/tutorials/20_player_annotations.py
@@ -38,7 +38,6 @@ from mne.viz import set_browser_backend
 from mne_lsl.player import PlayerLSL
 from mne_lsl.stream import StreamLSL
 
-
 annotations = Annotations(
     onset=[1, 2, 3],
     duration=[0.1, 0.2, 0.3],


### PR DESCRIPTION
Following https://github.com/mscheltienne/template-python/issues/58 where @scott-huberty dropped `pydocstyle` from the requirements in my template, application to a larger code-base.