### PR TITLE
add mailmap and enforce sorting of it

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+Arnaud Desvachez <arnaud.desvachez@gmail.com> adesvachez <charles.vila@jooce.ch>
+Arnaud Desvachez <arnaud.desvachez@gmail.com> Arnaud Desvachez <arnad.desvachez@gmail.com>
+Arnaud Desvachez <arnaud.desvachez@gmail.com> desvache <arnaud.desvachez@epfl.ch>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+dnastars <43815225+dnastars@users.noreply.github.com>
+Eric Larson <larson.eric.d@gmail.com>
+github-actions[bot] <github-actions[bot]@users.noreply.github.com> github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+Kyuhwa Lee <lee.kyuh@gmail.com> dbdq <lee.kyuh@gmail.com>
+Kyuhwa Lee <lee.kyuh@gmail.com> Kyuhwa Lee <kyu.lee@epfl.ch>
+Mathieu Scheltienne <mathieu.scheltienne@gmail.com> Mathieu Scheltienne <73893616+mscheltienne@users.noreply.github.com>
+Mathieu Scheltienne <mathieu.scheltienne@gmail.com> Mathieu Scheltienne <mathieu.scheltienne@epfl.ch>
+Mathieu Scheltienne <mathieu.scheltienne@gmail.com> Mathieu Scheltienne <mathieu.scheltienne@fcbg.ch>
+Mathieu Scheltienne <mathieu.scheltienne@gmail.com> mscheltienne <mathieu.scheltienne@fcbg.ch>
+Mathieu Scheltienne <mathieu.scheltienne@gmail.com> PC-NeuroTin <mathieu.scheltienne@gmail.com>
+pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+Quentin Uhl <53340743+QuentinUhl@users.noreply.github.com>
+Valeria de Seta <70070529+valedeseta@users.noreply.github.com>
+Дим Щ <sherdim@gmail.com>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,10 @@ repos:
           - id: yamllint
             args: [--strict, -c, .yamllint.yaml]
             files: (.github/|.codecov.yaml|.pre-commit-config.yaml|.yamllint.yaml)
+
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.6.0
+      hooks:
+          - id: file-contents-sorter
+            files: ^.mailmap
+            args: ["--ignore-case"]


### PR DESCRIPTION
Today I needed to mention/cite MNE-LSL (in a grant proposal), so I used `git shortlog -nse` to get an author list for version 1.5.0.  There were many duplicate names, so I made a `.mailmap` to clean up the result. Here it is.