### PR TITLE
Don't use public get_data in epoch acquisition to avoid resetting the number of new samples

### DIFF
--- a/doc/development/changes/latest.rst
+++ b/doc/development/changes/latest.rst
@@ -19,4 +19,4 @@
 Version 1.8
 ===========
 
-- xxx
+- Fix epoching with :class:`~mne_lsl.stream.EpochsStream` which was erroneously resetting the property ``n_new_samples`` from the attached :class:`~mne_lsl.stream.StreamLSL` objects (:pr:`371` by `Mathieu Scheltienne`_)

--- a/src/mne_lsl/stream/base.py
+++ b/src/mne_lsl/stream/base.py
@@ -280,7 +280,7 @@ class BaseStream(ABC, ContainsMixin, SetChannelsMixin):
             Delay in seconds between 2 acquisition during which chunks of data are
             pulled from the connected device. If ``0``, the automatic acquisition in a
             background thread is disabled and the user must manually call the
-            acquisition method to pull new samples.
+            acquisition method ``Stream.acquire()`` to pull new samples.
 
         Returns
         -------

--- a/src/mne_lsl/stream/epochs.py
+++ b/src/mne_lsl/stream/epochs.py
@@ -440,7 +440,7 @@ class EpochsStream:
             # split the different acquisition scenarios to retrieve new events to add to
             # the buffer.
             data, ts = _remove_empty_elements(
-                self._stream._buffer[:, :].T, self._stream._timestamps[:]
+                self._stream._buffer.T, self._stream._timestamps
             )
             if self._event_stream is None:
                 picks_events = _picks_to_idx(
@@ -470,7 +470,7 @@ class EpochsStream:
                 )
                 data_events, ts_events = _remove_empty_elements(
                     self._event_stream._buffer[:, picks].T,
-                    self._event_stream._timestamps[:],
+                    self._event_stream._timestamps,
                 )
                 events = _find_events_in_stim_channels(
                     data_events, self._event_channels, self._info["sfreq"]
@@ -499,7 +499,7 @@ class EpochsStream:
                 )
                 data_events, ts_events = _remove_empty_elements(
                     self._event_stream._buffer[:, picks].T,
-                    self._event_stream._timestamps[:],
+                    self._event_stream._timestamps,
                 )
                 events = np.vstack(
                     [

--- a/src/mne_lsl/stream/epochs.py
+++ b/src/mne_lsl/stream/epochs.py
@@ -279,7 +279,10 @@ class EpochsStream:
         ----------
         acquisition_delay : float
             Delay in seconds between 2 updates at which the event stream is queried for
-            new events, and thus at which the epochs are updated.
+            new events, and thus at which the epochs are updated. If ``0``, the
+            automatic acquisition in a background thread is disabled and the user must
+            manually call the acquisition method
+            :meth:~`mne_lsl.stream.EpochsStream.acquire` to pull new samples.
 
             .. note::
 

--- a/src/mne_lsl/stream/epochs.py
+++ b/src/mne_lsl/stream/epochs.py
@@ -439,8 +439,9 @@ class EpochsStream:
                 return
             # split the different acquisition scenarios to retrieve new events to add to
             # the buffer.
-            data, ts = self._stream.get_data(exclude=())
-            data, ts = _remove_empty_elements(data, ts)
+            data, ts = _remove_empty_elements(
+                self._stream._buffer[:, :].T, self._stream._timestamps[:]
+            )
             if self._event_stream is None:
                 picks_events = _picks_to_idx(
                     self._stream._info, self._event_channels, exclude="bads"
@@ -461,10 +462,16 @@ class EpochsStream:
                 self._event_stream is not None
                 and self._event_stream._info["sfreq"] != 0
             ):
-                data_events, ts_events = self._event_stream.get_data(
-                    picks=self._event_channels, exclude=()
+                picks = _picks_to_idx(
+                    self._event_stream._info,
+                    self._event_channels,
+                    none="all",
+                    exclude=(),
                 )
-                data_events, ts_events = _remove_empty_elements(data_events, ts_events)
+                data_events, ts_events = _remove_empty_elements(
+                    self._event_stream._buffer[:, picks].T,
+                    self._event_stream._timestamps[:],
+                )
                 events = _find_events_in_stim_channels(
                     data_events, self._event_channels, self._info["sfreq"]
                 )
@@ -484,10 +491,16 @@ class EpochsStream:
                 # don't select only the new events as they might all fall outside of
                 # the attached stream ts buffer, instead always look through all
                 # available events.
-                data_events, ts_events = self._event_stream.get_data(
-                    picks=self._event_channels, exclude=()
+                picks = _picks_to_idx(
+                    self._event_stream._info,
+                    self._event_channels,
+                    none="all",
+                    exclude=(),
                 )
-                data_events, ts_events = _remove_empty_elements(data_events, ts_events)
+                data_events, ts_events = _remove_empty_elements(
+                    self._event_stream._buffer[:, picks].T,
+                    self._event_stream._timestamps[:],
+                )
                 events = np.vstack(
                     [
                         np.arange(ts_events.size, dtype=np.int64),


### PR DESCRIPTION
Closes #369