### PR TITLE
Fix intersphinx link in tutorial

### DIFF
--- a/tutorials/00_introduction.py
+++ b/tutorials/00_introduction.py
@@ -77,9 +77,9 @@ Within MNE-LSL, the :class:`~mne_lsl.player.PlayerLSL` generates a simulated LSL
 utilizing data from a :class:`mne.io.Raw` file or object. This stream inherits its
 description and channel specifications from the associated :class:`~mne.Info`. This
 information encompasses channel properties, channel locations, filters, digitization,
-and `SSP projectors`_. The :class:~mne_lsl.player.PlayerLSL subsequently publishes data
-at regular intervals and seamlessly loops back to the starting point once the end of the
-file is reached.
+and `SSP projectors`_. The :class:`~mne_lsl.player.PlayerLSL` subsequently publishes
+data at regular intervals and seamlessly loops back to the starting point once the end
+of the file is reached.
 """
 
 import time


### PR DESCRIPTION
Looking through the introduction tutorial I noticed a tiny syntax error for one of the intersphinx links.