### PR TITLE
Fix source code links in documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,6 +233,7 @@ def linkcode_resolve(domain: str, info: dict[str, str]) -> str | None:
         pyobject = module
         for elt in info["fullname"].split("."):
             pyobject = getattr(pyobject, elt)
+        pyobject = inspect.unwrap(pyobject)
         fname = inspect.getsourcefile(pyobject).replace("\\", "/")
         if not Path(fname).exists():
             return None
@@ -258,7 +259,7 @@ def linkcode_resolve(domain: str, info: dict[str, str]) -> str | None:
     else:
         maint_version = ".".join(release.rsplit(".")[:2])
         branch = f"maint/{maint_version}"
-    return f"{gh_url}/blob/{branch}/{package}/{fname}#{lines}"
+    return f"{gh_url}/blob/{branch}/src/{package}/{fname}#{lines}"
 
 
 # -- sphinx-gallery --------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes the 404 error with the [source] link on the documentation page.
1. The source code for `mne_lsl` has been moved to the `src` subdirectory.
2. For functions decorated with `verbose`, the file path returned by `inspect.getsourcefile` may point to the decorator's file instead of the actual source file of the function.

   The following links are affected:

   ```
   {'module': 'mne_lsl.player', 'fullname': 'PlayerLSL.anonymize'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L88-L124
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.anonymize'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L235-L267
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.filter'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L463-L523
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.notch_filter'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L645-L735
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.rename_channels'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L784-L819
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.set_channel_types'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L833-L873
   {'module': 'mne_lsl.stream', 'fullname': 'BaseStream.set_montage'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L1008-L1057
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.anonymize'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L235-L267
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.filter'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L463-L523
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.notch_filter'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L645-L735
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.rename_channels'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L784-L819
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.set_channel_types'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L833-L873
   {'module': 'mne_lsl.stream', 'fullname': 'StreamLSL.set_montage'} https://github.com/mne-tools/mne-lsl/blob/maint/1.8/src/mne_lsl/utils/logs.py#L1008-L1057
   ```

This is a script that demonstrates issue 2:

```python
import inspect
from importlib import import_module


def get_source_file(module_name, method_name, unwrap):
    module = import_module(module_name)

    method = module
    for elt in method_name.split("."):
        method = getattr(method, elt)

    if unwrap:
        method = inspect.unwrap(method)

    return inspect.getsourcefile(method).replace("\\", "/")


def print_source_file(module_name, method_name):
    print(
        module_name,
        method_name,
        get_source_file(module_name, method_name, False))
    print(
        module_name,
        method_name,
        get_source_file(module_name, method_name, True))


if __name__ == '__main__':
    print_source_file('mne_lsl.stream', 'BaseStream.add_reference_channels') # @fill_doc
    print_source_file('mne_lsl.stream', 'BaseStream.anonymize')  # @verbose, @fill_doc
    print_source_file('mne_lsl.player', 'PlayerLSL.anonymize')
```

Output:

```
(mne-lsl-doc) D:\GitHub\mne-tools>python .\get_source_line_v2.py
mne_lsl.stream BaseStream.add_reference_channels C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/stream/base.py
mne_lsl.stream BaseStream.add_reference_channels C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/stream/base.py
mne_lsl.stream BaseStream.anonymize C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/utils/logs.py
mne_lsl.stream BaseStream.anonymize C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/stream/base.py
mne_lsl.player PlayerLSL.anonymize C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/utils/logs.py
mne_lsl.player PlayerLSL.anonymize C:/Users/myd/.conda/envs/mne-lsl-doc/Lib/site-packages/mne_lsl/player/_base.py
```

