### PR TITLE
Fix for annotation with no duration

### DIFF
--- a/doc/development/changes/authors.inc
+++ b/doc/development/changes/authors.inc
@@ -4,4 +4,5 @@
 .. _Kyuhwa Lee: https://github.com/dbdq
 .. _Mathieu Scheltienne: https://mathieu.scheltienne.net
 .. _Thomas Binns: https://github.com/tsbinns
+.. _Tom Ma: https://github.com/myd7349
 .. _Toni M. Brotons: https://github.com/toni-neurosc

--- a/doc/development/changes/latest.rst
+++ b/doc/development/changes/latest.rst
@@ -20,3 +20,5 @@ Version 1.9
 ===========
 
 - Fix sphinx formatting in tutorials (:pr:`388` and :pr:`389` by `Thomas Binns`_)
+- Fix source links in the documentation (:pr:`398` by `Tom Ma`_)
+- Fix stream of annotations by a :class:`~mne_lsl.player.PlayerLSL` when the annotation duration is 0 (:pr:`399` by `Mathieu Scheltienne`_)

--- a/src/mne_lsl/player/player_lsl.pyi
+++ b/src/mne_lsl/player/player_lsl.pyi
@@ -60,7 +60,7 @@ class PlayerLSL(BasePlayer):
     the chunk are pushed on the annotation :class:`~mne_lsl.lsl.StreamOutlet`. The
     :class:`~mne.Annotations` are pushed with a timestamp corrected for the annotation
     onset in regards to the chunk beginning. However, :class:`~mne.Annotations` push is
-    *not* delayed until the the annotation timestamp or until the end of the chunk.
+    *not* delayed until the annotation timestamp or until the end of the chunk.
     Thus, an :class:`~mne.Annotations` can arrived at the client
     :class:`~mne_lsl.lsl.StreamInlet` "ahead" of time, i.e. earlier than the current
     time (as returned by the function :func:`~mne_lsl.lsl.local_clock`). Thus, it is
@@ -89,6 +89,12 @@ class PlayerLSL(BasePlayer):
     streamed on a channel correspond to the duration of the :class:`~mne.Annotations`.
     Thus, a sample on this :class:`~mne_lsl.lsl.StreamOutlet` is a one-hot encoded
     vector of the :class:`~mne.Annotations` description/duration.
+
+    .. note::
+
+        If the duration of an annotatation is ``0``, then the one-hot encoded vector
+        becomes a null vector. In this special case, the value ``-1`` is encoded and
+        denotes an annotation with a duration of ``0``.
     """
 
     _name: Incomplete

--- a/tutorials/20_player_annotations.py
+++ b/tutorials/20_player_annotations.py
@@ -22,6 +22,11 @@ description: ``'event1'``, ``'event2'``, and ``'event3'``. The event stream will
 channels, each corresponding to one of the 3 descriptions. When an annotation is
 streamed, it's duration is encoded as the value on its channel while the other channels
 remain to zero.
+
+.. note::
+
+    Annotation with a duration equal to zero are special cased and yield an encoded
+    value of ``-1``.
 """
 
 # sphinx_gallery_thumbnail_number = 2


### PR DESCRIPTION
Closes #392 

Instead of building a separate mechanism special casing entirely annotations streams with annotations that don't have a duration, let's just encode the value -1 on the annotation vector pushed to the stream outlet.