### PR TITLE
Update documentation of the pylsl differences

### DIFF
--- a/doc/resources/pylsl.rst
+++ b/doc/resources/pylsl.rst
@@ -5,8 +5,8 @@
 Differences with pylsl
 ======================
 
-Faster chunk pull
------------------
+Safer chunk pull default
+------------------------
 
 Arguably the most important difference, pulling a chunk of numerical data with
 :meth:`~mne_lsl.lsl.StreamInlet.pull_chunk` is faster than with its
@@ -53,7 +53,7 @@ Increasing the number of channels to 650, simulating an higher sample count yiel
 .. dropdown:: Timeit python code
     :animate: fade-in-slide-down
 
-    .. coode-block:: python
+    .. code-block:: python
 
         import ctypes
         import timeit
@@ -119,7 +119,7 @@ Note that ``pylsl`` pulling function support a ``dest_obj`` argument described a
     the appropriate number of samples. A numpy buffer must be order='C'.
 
 If a :class:`~numpy.ndarray` is used as ``dest_obj``, the memory re-allocation step
-described above is skipped, yielding better performance than ``mne_lsl.lsl`` at the constant
+described above is skipped, yielding better performance than ``mne_lsl.lsl`` at the cost
 of code complexity as the user is now responsible for the memory management.
 
 .. note::
@@ -176,4 +176,4 @@ Unique resolve function
 :func:`mne_lsl.lsl.resolve_streams` simplifies stream resolution with a unique function
 with similar functionalities.
 
-.. _pylsl pull_chunk: https://github.com/labstreaminglayer/pylsl/blob/16a4198087936386e866d7239bfde32d1fef6d6b/pylsl/pylsl.py#L862-L870
+.. _pylsl pull_chunk: https://github.com/labstreaminglayer/pylsl/blob/5e88eac4a4f82a809e0560fd4623e1735b3f57bf/src/pylsl/inlet.py#L265-L275

--- a/doc/resources/pylsl.rst
+++ b/doc/resources/pylsl.rst
@@ -97,7 +97,7 @@ Increasing the number of channels to 650, simulating an higher sample count yiel
             worst = max(times)
             avg = sum(times) / len(times)
 
-            # format with the corret unit
+            # format with the correct unit
             if best < 1e-6:
                 unit, factor = "ns", 1e9
             elif best < 1e-3:

--- a/doc/resources/pylsl.rst
+++ b/doc/resources/pylsl.rst
@@ -52,14 +52,16 @@ Note that ``pylsl`` pulling function support a ``dest_obj`` argument described a
     the appropriate number of samples. A numpy buffer must be order='C'.
 
 If a :class:`~numpy.ndarray` is used as ``dest_obj``, the memory re-allocation step
-described abvove is skipped, yielding similar performance to ``mne_lsl.lsl``. For the
+described above is skipped, yielding similar performance to ``mne_lsl.lsl``. For the
 same 1024 samples with 65 channels in double precision (``float64``), the pull operation
 takes:
 
 * 471 ns ± 1.7 ns with ``pylsl`` (with ``dest_obj`` argument as :class:`~numpy.ndarray`)
 
-Note that this performance improvement is absent for ``string`` based streams. Follow
-:issue:`225` for more information.
+.. note::
+
+    This performance improvement is absent for ``string`` based streams. Follow
+    :issue:`225` for more information.
 
 Convenience methods
 -------------------


### PR DESCRIPTION
Relates to https://github.com/mne-tools/mne-lsl/issues/426

@matthiasdold Here is a PR updating the documentation comparing `pylsl` and `mne-lsl` implementation of `pull_chunk`. It was written ~2 years ago, and I could easily reproduce the difference between the list comprehension and `numpy.frombuffer`, but I don't know how I pulled the number for `dest_obj`. My guess is that I mistakenly measured the array creation within the measurement loop (recreating the array on every pull operation). 

I updated the documentation accordingly, adding:
- a reproducible code snippet using `timeit`
- re-measured values, fixing also the unit for the list-comprehension
- measurements with (1024, 65) and (1024, 650) values, showing the empirical `O(1)` performance of `numpy.frombuffer`

And removing the `dest_obj` approach claim, which is probably even faster and I might re-introduce it in `mne-lsl` at least for internal operations with the `StreamLSL` object which could benefit from it (although it does increase the code complexity). 