### PR TITLE
Update paper.bib

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -36,7 +36,7 @@
 }
 
 @software{mne-realtime,
- author        = {MNE-realtime contributors},
+ author        = {{MNE-realtime contributors}},
  title         = {MNE-realtime},
  howpublished  = {\url{https://mne.tools/mne-realtime/}},
  note          = {Realtime analysis of MEG/EEG data with MNE. Accessed: 2024-08-08}


### PR DESCRIPTION
Following the example paper, https://joss.readthedocs.io/en/latest/example_paper.html, this grouping allows for the collective group name to appear and not be parsed as personal name