### PR TITLE
Minor editing fixes for JOSS paper

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -10,8 +10,8 @@
 }
 
 @misc{brainflow,
-  author       = {BrainFlow},
-  title        = {BrainFlow is a library intended to obtain, parse and analyze EEG, EMG, ECG and other kinds of data from biosensors.},
+  author       = {BrainFlow contributors},
+  title        = {BrainFlow},
   howpublished = {\url{https://brainflow.org}},
   note         = {Accessed: 2024-08-08}
 }
@@ -39,10 +39,12 @@
  year          = {2020}
 }
 
-@software{LSL,
-  author       = {Stenner, Tristan and Boulay, Chadwick and others},
+@misc{LSL,
+  author       = {{LabStreamingLayer contributors}},
   title        = {LabStreamingLayer},
-  howpublished = {\url{https://github.com/sccn/labstreaminglayer}},
+  publisher    = {GitHub},
+  journal      = {GitHub repository},
+  url          = {https://github.com/sccn/labstreaminglayer},
   note         = {LSL is an open-source networked middleware ecosystem to stream, receive, synchronize, and record neural, physiological, and behavioral data streams acquired from diverse sensor hardware. Accessed: 2025-05-28}
 }
 
@@ -62,15 +64,17 @@
 }
 
 @software{openbci,
- author        = {OpenBCI},
+ author        = {{OpenBCI contributors}},
  title         = {OpenBCI},
  howpublished  = {\url{https://openbci.com}},
  note          = {OpenBCI creates open-source tools for biosensing and neuroscience. Accessed: 2024-08-08}
 }
 
-@software{pylsl,
-  author       = {Boulay, Chadwick and Stenner, Tristan and others},
+@misc{pylsl,
+  author       = {{pyLSL contributors}},
   title        = {pyLSL},
-  howpublished = {\url{https://github.com/labstreaminglayer/pylsl}},
+  publisher    = {GitHub},
+  journal      = {GitHub repository},
+  url          = {https://github.com/labstreaminglayer/pylsl},
   note         = {Python interface to the Lab Streaming Layer. Accessed: 2024-08-08}
 }

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -57,7 +57,7 @@ A critical challenge in real-time applications is the need for direct access to 
 streams from measurement devices, which often rely on device-specific APIs. Adapting a
 real-time application from one device to another can be labor-intensive, as it requires
 modifications to the entire communication protocol. To address this issue, the Lab
-Streaming Layer [@LSL] offers a standardized protocol for streaming time-series
+Streaming Layer [LSL\; @LSL] offers a standardized protocol for streaming time-series
 data from multiple devices in real-time. LSL has gained significant popularity,
 particularly among EEG manufacturers, many of whom now provide LSL streaming
 capabilities out-of-the-box with their devices. By abstracting the complexities of
@@ -121,7 +121,7 @@ neurophysiological research community.
 
 # Acknowledgements
 
-We would like to acknowledge the the LSL developers, with special thanks to Tristan
+We would like to acknowledge the LSL developers, with special thanks to Tristan
 Stenner and Chadwick Boulay.
 
 MNE-LSL development is supported by the Fondation Campus Biotech Geneva, Geneva,


### PR DESCRIPTION
[Part of JOSS review at: openjournals/joss-reviews#8088]
- fix duplicated word
- mention LSL abbreviation earlier
- use slightly different format for GitHub citations
- uniformly cite "... contributors"

Please merge if you agree with the changes. Most should be uncontroversial, the only fundamental change is to replace the Stenner, Boulay, et al. authorship by the more generic "LabStreamingLayer contributors". I'd err on the side of caution here in the absence of clear citation information from the project itself, since  a list of names should at least include the original author C. Kothe (note they are the only author mentioned in the PyPI package).  