### PR TITLE
Fix Brainflow contributors in papers.bib

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -10,7 +10,7 @@
 }
 
 @misc{brainflow,
-  author       = {BrainFlow contributors},
+  author       = {{BrainFlow contributors}},
   title        = {BrainFlow},
   howpublished = {\url{https://brainflow.org}},
   note         = {Accessed: 2024-08-08}


### PR DESCRIPTION
[Part of JOSS review at: https://github.com/openjournals/joss-reviews/issues/8088]

Apologies, but I just realized that #456 introduced a small error: the Brainflow contributors were interpreted as a name, i.e. as "contributors, B.". This PR should fix this, giving the expected reference/citation.