### PR TITLE
Update abi3 mode and make installable from zipball

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
       - run: uv python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
-          GOT_VERSION=$(pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
+          GOT_VERSION=$(uv pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
           uv python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,13 +197,13 @@ jobs:
           activate-environment: true
           python-version: '3.13'
       - run: uvx twine check --strict dist/*
-      - run: pip install dist/*.tar.gz
-      - run: python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - run: uv pip install dist/*.tar.gz
+      - run: uv python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
           GOT_VERSION=$(pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
-          python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
+          uv python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
 
 
   doc-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,8 @@ jobs:
       - run: ls -alt . && ls -alt dist/
       - uses: astral-sh/setup-uv@v7
       - run: uvx twine check --strict dist/*
+      - run: uvx pip install dist/*.tar.gz
+      - run: uvx python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
 
   doc-build:
     needs: cibuildwheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,7 +201,7 @@ jobs:
       - run: uv run python -c "import mne_lsl; from packaging.version import parse; assert parse(mne_lsl.__version__) > parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
-          GOT_VERSION=$(uv pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
+          GOT_VERSION=$(uv pip show mne-lsl | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
           uv run python -c "from packaging.version import parse; assert parse('$GOT_VERSION') > parse('1.0.0'), '$GOT_VERSION'"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
       - run: uv run python -c "import mne_lsl; from packaging.version import parse; assert parse(mne_lsl.__version__) > parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
+          uv pip show mne-lsl
           GOT_VERSION=$(uv pip show mne-lsl | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
           uv run python -c "from packaging.version import parse; assert parse('$GOT_VERSION') > parse('1.0.0'), '$GOT_VERSION'"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,12 +198,12 @@ jobs:
           python-version: '3.13'
       - run: uvx twine check --strict dist/*
       - run: uv pip install dist/*.tar.gz
-      - run: uv python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - run: uv run "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
           GOT_VERSION=$(uv pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
-          uv python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
+          uv run "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
 
 
   doc-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,12 +198,12 @@ jobs:
           python-version: '3.13'
       - run: uvx twine check --strict dist/*
       - run: uv pip install dist/*.tar.gz
-      - run: uv run python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - run: uv run python -c "import mne_lsl; from packaging.version import parse; assert parse(mne_lsl.__version__) > parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
           GOT_VERSION=$(uv pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
-          uv run python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
+          uv run python -c "from packaging.version import parse; assert parse('$GOT_VERSION') > parse('1.0.0'), '$GOT_VERSION'"
 
 
   doc-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,9 @@ jobs:
     name: run twine check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -190,9 +193,18 @@ jobs:
           path: dist
       - run: ls -alt . && ls -alt dist/
       - uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: true
+          python-version: '3.13'
       - run: uvx twine check --strict dist/*
-      - run: uvx pip install dist/*.tar.gz
-      - run: uvx python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - run: pip install dist/*.tar.gz
+      - run: python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - name: Check metadata
+        run: |
+          GOT_VERSION=$(pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
+          echo "GOT_VERSION=$GOT_VERSION"
+          python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
+
 
   doc-build:
     needs: cibuildwheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,12 +198,12 @@ jobs:
           python-version: '3.13'
       - run: uvx twine check --strict dist/*
       - run: uv pip install dist/*.tar.gz
-      - run: uv run "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
+      - run: uv run python -c "import mne_lsl, packaging; assert packaging.version.parse(mne_lsl.__version__) > packaging.version.parse('1.0.0'), mne_lsl.__version__"
       - name: Check metadata
         run: |
           GOT_VERSION=$(uv pip show dist/*.tar.gz | grep Version: | awk '{print $2}')
           echo "GOT_VERSION=$GOT_VERSION"
-          uv run "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
+          uv run python -c "import packaging; assert packaging.version.parse('$GOT_VERSION') > packaging.version.parse('1.0.0'), '$GOT_VERSION'"
 
 
   doc-build:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from setuptools import setup
-from setuptools.command.bdist_wheel import bdist_wheel
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.develop import develop as _develop
 from setuptools.dist import Distribution
@@ -107,19 +106,11 @@ class develop(_develop):  # noqa: D101
         super().run()
 
 
-class bdist_wheel_abi3(bdist_wheel):  # noqa: D101
-    def get_tag(self):  # noqa: D102
-        python, abi, plat = super().get_tag()
-        if python.startswith("cp") and not abi.endswith("t"):
-            return "cp311", "abi3", plat
-        return python, abi, plat
-
-
 setup(
     cmdclass={
         "build_ext": build_ext,
-        "bdist_wheel": bdist_wheel_abi3,
         "develop": develop,
     },
+    options={"bdist_wheel": {"py_limited_api": "cp311"}},
     distclass=BinaryDistribution,
 )

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import platform
 import shutil
 import subprocess
+import sysconfig
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -106,11 +107,16 @@ class develop(_develop):  # noqa: D101
         super().run()
 
 
+options = dict()
+is_freethreaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+if not is_freethreaded:
+    options["bdist_wheel"] = {"py_limited_api": "cp311"}
+
 setup(
     cmdclass={
         "build_ext": build_ext,
         "develop": develop,
     },
-    options={"bdist_wheel": {"py_limited_api": "cp311"}},
+    options=options,
     distclass=BinaryDistribution,
 )


### PR DESCRIPTION
As part of investigating https://github.com/conda-forge/mne-lsl-feedstock/pull/34, let's

- [x] Add a little test that the `sdist` version is reasonable (not `0.0.0`) when installed
- [x] Add `git-archival` stuff to make it so that `git clone` of full repo is not necessary to install a correctly versioned `mne-lsl` from `main`