### PR TITLE
FIX preserve manufacturer metadata from StreamInfo

### DIFF
--- a/doc/development/changes/authors.inc
+++ b/doc/development/changes/authors.inc
@@ -1,4 +1,5 @@
 .. _Alin G. Chitu: https://github.com/agchitu
+.. _Anna Sokolova: https://github.com/ZyntZ
 .. _Arnaud Desvachez: https://github.com/dnastars
 .. _Daniel McCloy: https://dan.mccloy.info
 .. _Eric Larson: https://github.com/larsoner

--- a/doc/development/changes/latest.rst
+++ b/doc/development/changes/latest.rst
@@ -24,3 +24,4 @@ Version 1.15
 - Restore macOS intel wheels (:pr:`565` by `Eric Larson`_)
 - Add a ``recover`` argument to :meth:`~mne_lsl.stream.StreamLSL.connect` to disable silent recovery of lost streams (:pr:`565` by `Eric Larson`_)
 - Fix an intermittent abort on inlet destruction by not closing the stream before destroying it, which could engage the ``liblsl`` stream recovery machinery whose cancellation races with the destruction (:pr:`565` by `Eric Larson`_)
+- Fix parsing of manufacturer metadata from :class:`~mne_lsl.lsl.StreamInfo` (:pr:`578` by `Anna Sokolova`_)

--- a/src/mne_lsl/utils/meas_info.py
+++ b/src/mne_lsl/utils/meas_info.py
@@ -217,8 +217,7 @@ def _read_desc_sinfo(
         ch_units = [_ch_unit_mul_named[0]] * n_channels
     assert len(ch_units) == n_channels
 
-    # TODO: retrieve manufacturer from StreamInfo.desc
-    manufacturer = None
+    manufacturer = desc.desc.child_value("manufacturer") or None
     return ch_names, ch_types, ch_units, manufacturer
 
 

--- a/tests/utils/test_meas_info.py
+++ b/tests/utils/test_meas_info.py
@@ -170,6 +170,19 @@ def test_manufacturer() -> None:
     assert info["device_info"]["model"] == "101"
 
 
+def test_manufacturer_from_sinfo() -> None:
+    """Test reading manufacturer information from a StreamInfo."""
+    ch_names = ["F7", "Fp2", "STI101", "EOG"]
+    ch_types = ["eeg", "eeg", "stim", "eog"]
+    sinfo = StreamInfo("pytest", "eeg", 4, 1024, "float32", uuid.uuid4().hex)
+    sinfo.set_channel_names(ch_names)
+    sinfo.set_channel_types(ch_types)
+    sinfo.desc.append_child_value("manufacturer", "101")
+
+    info = create_info(4, 1024, "eeg", sinfo)
+    assert info["device_info"]["model"] == "101"
+
+
 def test_valid_info_from_sinfo() -> None:
     """Test creation of a valid info from a SreamInfo."""
     sinfo = StreamInfo("pytest", "eeg", 4, 101, "float32", uuid.uuid4().hex)


### PR DESCRIPTION
## Summary

Preserve manufacturer metadata when converting a live `StreamInfo` description to an MNE `Info` object.

## Problem

`create_info()` already reads `manufacturer` from dictionary descriptions, including XDF-style metadata. However, `_read_desc_sinfo()` always returned `None`, even when the extended `StreamInfo` description contained a `<manufacturer>` element. The value was therefore silently dropped for live LSL metadata.

## Changes

- Read the direct `<manufacturer>` child from `StreamInfo.desc`.
- Map a missing or empty XML value to `None`, matching the current dictionary path.
- Add a focused regression test for the `StreamInfo` conversion path.
- Add the author reference and Version 1.15 changelog entry under `doc/`.

## Validation

```console
pytest tests/utils/test_meas_info.py -q
# 6 passed in 0.12s

ruff format --check src/mne_lsl/utils/meas_info.py tests/utils/test_meas_info.py
# 2 files already formatted

ruff check src/mne_lsl/utils/meas_info.py tests/utils/test_meas_info.py
# All checks passed!